### PR TITLE
An attempt to add cancellation token to Async methods (#41)

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/StoneTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/StoneTests.cs
@@ -7,6 +7,8 @@
 namespace Dropbox.Api.Unit.Tests
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Dropbox.Api.Files;
     using Dropbox.Api.Stone;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,9 +23,9 @@ namespace Dropbox.Api.Unit.Tests
         /// Smoke test for nested unions.
         /// </summary>
         [TestMethod]
-        public void TestNestedUnion()
+        public async Task TestNestedUnion()
         {
-            var result = JsonWriter.Write(
+            var result = await JsonWriter.WriteAsync(
                 new GetMetadataError.Path(LookupError.NotFound.Instance),
                 GetMetadataError.Encoder);
 
@@ -31,6 +33,24 @@ namespace Dropbox.Api.Unit.Tests
 
             Assert.IsTrue(obj.IsPath);
             Assert.IsTrue(obj.AsPath.Value.IsNotFound);
+        }
+
+        /// <summary>
+        /// Smoke test for JsonWriter with cancellation token.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [TestMethod]
+        public async Task TestNestedUnionWithCancellation()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () =>
+            {
+               await JsonWriter.WriteAsync(
+                    new GetMetadataError.Path(LookupError.NotFound.Instance),
+                    GetMetadataError.Encoder,
+                    cancellationToken: cts.Token);
+            });
         }
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxClient.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxClient.cs
@@ -7,6 +7,7 @@
 namespace Dropbox.Api
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Dropbox.Api.Common;
 
@@ -256,10 +257,11 @@ namespace Dropbox.Api
         /// Refreshes access token regardless of if existing token is expired.
         /// </summary>
         /// <param name="scopeList">subset of scopes to refresh token with, or null to refresh with all scopes.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>true if token is successfully refreshed, false otherwise.</returns>
-        public Task<bool> RefreshAccessToken(string[] scopeList)
+        public Task<bool> RefreshAccessToken(string[] scopeList, CancellationToken cancellationToken = default)
         {
-            return this.requestHandler.RefreshAccessToken(scopeList);
+            return this.requestHandler.RefreshAccessToken(scopeList, cancellationToken);
         }
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -148,7 +148,7 @@ namespace Dropbox.Api
             IDecoder<TError> errorDecoder,
             CancellationToken cancellationToken)
         {
-            var serializedArg = JsonWriter.Write(request, requestEncoder);
+            var serializedArg = await JsonWriter.WriteAsync(request, requestEncoder, cancellationToken: cancellationToken);
             var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Rpc, serializedArg, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -191,7 +191,7 @@ namespace Dropbox.Api
             IDecoder<TError> errorDecoder,
             CancellationToken cancellationToken)
         {
-            var serializedArg = JsonWriter.Write(request, requestEncoder, true);
+            var serializedArg = await JsonWriter.WriteAsync(request, requestEncoder, true, cancellationToken);
             var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Upload, serializedArg, body, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -232,7 +232,7 @@ namespace Dropbox.Api
             IDecoder<TError> errorDecoder,
             CancellationToken cancellationToken)
         {
-            var serializedArg = JsonWriter.Write(request, requestEncoder, true);
+            var serializedArg = await JsonWriter.WriteAsync(request, requestEncoder, true, cancellationToken);
             var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Download, serializedArg, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -530,7 +530,7 @@ namespace Dropbox.Api
             {
                 request.Headers.TryAddWithoutValidation(
                     "Dropbox-Api-Path-Root",
-                    JsonWriter.Write(this.pathRoot, PathRoot.Encoder));
+                    await JsonWriter.WriteAsync(this.pathRoot, PathRoot.Encoder, cancellationToken: cancellationToken));
             }
 
             var completionOption = HttpCompletionOption.ResponseContentRead;

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using System.Threading;
+
 namespace Dropbox.Api
 {
     using System;
@@ -131,6 +133,7 @@ namespace Dropbox.Api
         /// <param name="requestEncoder">The request encoder.</param>
         /// <param name="responseDecoder">The response decoder.</param>
         /// <param name="errorDecoder">The error decoder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An asynchronous task for the response.</returns>
         /// <exception cref="ApiException{TError}">
         /// This exception is thrown when there is an error reported by the server.
@@ -142,10 +145,11 @@ namespace Dropbox.Api
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder)
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken)
         {
             var serializedArg = JsonWriter.Write(request, requestEncoder);
-            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Rpc, serializedArg)
+            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Rpc, serializedArg, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             if (res.IsError)
@@ -171,6 +175,7 @@ namespace Dropbox.Api
         /// <param name="requestEncoder">The request encoder.</param>
         /// <param name="responseDecoder">The response decoder.</param>
         /// <param name="errorDecoder">The error decoder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An asynchronous task for the response.</returns>
         /// <exception cref="ApiException{TError}">
         /// This exception is thrown when there is an error reported by the server.
@@ -183,10 +188,11 @@ namespace Dropbox.Api
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder)
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken)
         {
             var serializedArg = JsonWriter.Write(request, requestEncoder, true);
-            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Upload, serializedArg, body)
+            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Upload, serializedArg, body, cancellationToken)
                 .ConfigureAwait(false);
 
             if (res.IsError)
@@ -211,6 +217,7 @@ namespace Dropbox.Api
         /// <param name="requestEncoder">The request encoder.</param>
         /// <param name="responseDecoder">The response decoder.</param>
         /// <param name="errorDecoder">The error decoder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An asynchronous task for the response.</returns>
         /// <exception cref="ApiException{TError}">
         /// This exception is thrown when there is an error reported by the server.
@@ -222,10 +229,11 @@ namespace Dropbox.Api
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder)
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken)
         {
             var serializedArg = JsonWriter.Write(request, requestEncoder, true);
-            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Download, serializedArg)
+            var res = await this.RequestJsonStringWithRetry(host, route, auth, RouteStyle.Download, serializedArg, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             if (res.IsError)
@@ -242,8 +250,9 @@ namespace Dropbox.Api
         /// Uses the refresh token to obtain a new access token.
         /// </summary>
         /// <param name="scopeList">The scope list.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public async Task<bool> RefreshAccessToken(string[] scopeList = null)
+        public async Task<bool> RefreshAccessToken(string[] scopeList = null, CancellationToken cancellationToken = default)
         {
             if (this.options.OAuth2RefreshToken == null || this.options.AppKey == null)
             {
@@ -272,7 +281,7 @@ namespace Dropbox.Api
 
             var bodyContent = new FormUrlEncodedContent(parameters);
 
-            var response = await this.defaultHttpClient.PostAsync(url, bodyContent).ConfigureAwait(false);
+            var response = await this.defaultHttpClient.PostAsync(url, bodyContent, cancellationToken).ConfigureAwait(false);
 
             // if response is an invalid grant, we want to throw this exception rather than the one thrown in
             // response.EnsureSuccessStatusCode();
@@ -338,6 +347,7 @@ namespace Dropbox.Api
         /// <param name="requestArg">The request argument.</param>
         /// <param name="body">The body to upload if <paramref name="routeStyle"/>
         /// is <see cref="RouteStyle.Upload"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The asynchronous task with the result.</returns>
         private async Task<Result> RequestJsonStringWithRetry(
             string host,
@@ -345,7 +355,8 @@ namespace Dropbox.Api
             string auth,
             RouteStyle routeStyle,
             string requestArg,
-            Stream body = null)
+            Stream body = null,
+            CancellationToken cancellationToken = default)
         {
             var attempt = 0;
             var hasRefreshed = false;
@@ -367,14 +378,14 @@ namespace Dropbox.Api
                 }
             }
 
-            await this.CheckAndRefreshAccessToken();
+            await this.CheckAndRefreshAccessToken(cancellationToken);
             try
             {
                 while (true)
                 {
                     try
                     {
-                        return await this.RequestJsonString(host, routeName, auth, routeStyle, requestArg, body)
+                        return await this.RequestJsonString(host, routeName, auth, routeStyle, requestArg, body, cancellationToken)
                             .ConfigureAwait(false);
                     }
                     catch (AuthException e)
@@ -387,7 +398,7 @@ namespace Dropbox.Api
                             }
                             else
                             {
-                                await this.RefreshAccessToken();
+                                await this.RefreshAccessToken(cancellationToken: cancellationToken);
                                 hasRefreshed = true;
                             }
                         }
@@ -418,9 +429,9 @@ namespace Dropbox.Api
                     // use exponential backoff
                     var backoff = TimeSpan.FromSeconds(Math.Pow(2, attempt) * r.NextDouble());
 #if PORTABLE40
-                    await TaskEx.Delay(backoff);
+                    await TaskEx.Delay(backoff, cancellationToken);
 #else
-                    await Task.Delay(backoff).ConfigureAwait(false);
+                    await Task.Delay(backoff, cancellationToken).ConfigureAwait(false);
 #endif
                     if (body != null)
                     {
@@ -471,6 +482,7 @@ namespace Dropbox.Api
         /// <param name="requestArg">The request argument.</param>
         /// <param name="body">The body to upload if <paramref name="routeStyle"/>
         /// is <see cref="RouteStyle.Upload"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The asynchronous task with the result.</returns>
         private async Task<Result> RequestJsonString(
             string host,
@@ -478,7 +490,8 @@ namespace Dropbox.Api
             string auth,
             RouteStyle routeStyle,
             string requestArg,
-            Stream body = null)
+            Stream body = null,
+            CancellationToken cancellationToken = default)
         {
             var hostname = this.options.HostMap[host];
             var uri = this.GetRouteUri(hostname, routeName);
@@ -554,7 +567,7 @@ namespace Dropbox.Api
             }
 
             var disposeResponse = true;
-            var response = await this.GetHttpClient(host).SendAsync(request, completionOption).ConfigureAwait(false);
+            var response = await this.GetHttpClient(host).SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
 
             var requestId = this.GetRequestId(response);
             try
@@ -640,14 +653,14 @@ namespace Dropbox.Api
             }
         }
 
-        private async Task<bool> CheckAndRefreshAccessToken()
+        private async Task<bool> CheckAndRefreshAccessToken(CancellationToken cancellationToken)
         {
             bool canRefresh = this.options.OAuth2RefreshToken != null && this.options.AppKey != null;
             bool needsRefresh = this.options.OAuth2AccessTokenExpiresAt.HasValue && DateTime.Now.AddSeconds(TokenExpirationBuffer) >= this.options.OAuth2AccessTokenExpiresAt.Value;
             bool needsToken = this.options.OAuth2AccessToken == null;
             if ((needsRefresh || needsToken) && canRefresh)
             {
-                return await this.RefreshAccessToken();
+                return await this.RefreshAccessToken(cancellationToken: cancellationToken);
             }
 
             return false;

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Account/AccountUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Account/AccountUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Account.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -34,14 +35,15 @@ namespace Dropbox.Api.Account.Routes
         /// <para>Sets a user's profile photo.</para>
         /// </summary>
         /// <param name="setProfilePhotoArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetProfilePhotoError"/>.</exception>
-        public t.Task<SetProfilePhotoResult> SetProfilePhotoAsync(SetProfilePhotoArg setProfilePhotoArg)
+        public t.Task<SetProfilePhotoResult> SetProfilePhotoAsync(SetProfilePhotoArg setProfilePhotoArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SetProfilePhotoArg, SetProfilePhotoResult, SetProfilePhotoError>(setProfilePhotoArg, "api", "/account/set_profile_photo", "user", global::Dropbox.Api.Account.SetProfilePhotoArg.Encoder, global::Dropbox.Api.Account.SetProfilePhotoResult.Decoder, global::Dropbox.Api.Account.SetProfilePhotoError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SetProfilePhotoArg, SetProfilePhotoResult, SetProfilePhotoError>(setProfilePhotoArg, "api", "/account/set_profile_photo", "user", global::Dropbox.Api.Account.SetProfilePhotoArg.Encoder, global::Dropbox.Api.Account.SetProfilePhotoResult.Decoder, global::Dropbox.Api.Account.SetProfilePhotoError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -64,16 +66,18 @@ namespace Dropbox.Api.Account.Routes
         /// <para>Sets a user's profile photo.</para>
         /// </summary>
         /// <param name="photo">Image to set as the user's new profile photo.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetProfilePhotoError"/>.</exception>
-        public t.Task<SetProfilePhotoResult> SetProfilePhotoAsync(PhotoSourceArg photo)
+        public t.Task<SetProfilePhotoResult> SetProfilePhotoAsync(PhotoSourceArg photo,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var setProfilePhotoArg = new SetProfilePhotoArg(photo);
 
-            return this.SetProfilePhotoAsync(setProfilePhotoArg);
+            return this.SetProfilePhotoAsync(setProfilePhotoArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Auth/AuthAppRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Auth/AuthAppRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Auth.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -34,14 +35,15 @@ namespace Dropbox.Api.Auth.Routes
         /// token.</para>
         /// </summary>
         /// <param name="tokenFromOAuth1Arg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TokenFromOAuth1Error"/>.</exception>
-        public t.Task<TokenFromOAuth1Result> TokenFromOauth1Async(TokenFromOAuth1Arg tokenFromOAuth1Arg)
+        public t.Task<TokenFromOAuth1Result> TokenFromOauth1Async(TokenFromOAuth1Arg tokenFromOAuth1Arg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TokenFromOAuth1Arg, TokenFromOAuth1Result, TokenFromOAuth1Error>(tokenFromOAuth1Arg, "api", "/auth/token/from_oauth1", "app", global::Dropbox.Api.Auth.TokenFromOAuth1Arg.Encoder, global::Dropbox.Api.Auth.TokenFromOAuth1Result.Decoder, global::Dropbox.Api.Auth.TokenFromOAuth1Error.Decoder);
+            return this.Transport.SendRpcRequestAsync<TokenFromOAuth1Arg, TokenFromOAuth1Result, TokenFromOAuth1Error>(tokenFromOAuth1Arg, "api", "/auth/token/from_oauth1", "app", global::Dropbox.Api.Auth.TokenFromOAuth1Arg.Encoder, global::Dropbox.Api.Auth.TokenFromOAuth1Result.Decoder, global::Dropbox.Api.Auth.TokenFromOAuth1Error.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -67,18 +69,20 @@ namespace Dropbox.Api.Auth.Routes
         /// <param name="oauth1Token">The supplied OAuth 1.0 access token.</param>
         /// <param name="oauth1TokenSecret">The token secret associated with the supplied
         /// access token.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TokenFromOAuth1Error"/>.</exception>
         public t.Task<TokenFromOAuth1Result> TokenFromOauth1Async(string oauth1Token,
-                                                                  string oauth1TokenSecret)
+                                                                  string oauth1TokenSecret,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var tokenFromOAuth1Arg = new TokenFromOAuth1Arg(oauth1Token,
                                                             oauth1TokenSecret);
 
-            return this.TokenFromOauth1Async(tokenFromOAuth1Arg);
+            return this.TokenFromOauth1Async(tokenFromOAuth1Arg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Auth/AuthUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Auth/AuthUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Auth.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -32,10 +33,11 @@ namespace Dropbox.Api.Auth.Routes
         /// <summary>
         /// <para>Disables the access token used to authenticate the call.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
-        public t.Task TokenRevokeAsync()
+        public t.Task TokenRevokeAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, enc.Empty, enc.Empty>(enc.Empty.Instance, "api", "/auth/token/revoke", "user", enc.EmptyEncoder.Instance, enc.EmptyDecoder.Instance, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, enc.Empty, enc.Empty>(enc.Empty.Instance, "api", "/auth/token/revoke", "user", enc.EmptyEncoder.Instance, enc.EmptyDecoder.Instance, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Check/CheckAppRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Check/CheckAppRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Check.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -37,11 +38,12 @@ namespace Dropbox.Api.Check.Routes
         /// infrastructure is working and that the app key and secret valid.</para>
         /// </summary>
         /// <param name="echoArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<EchoResult> AppAsync(EchoArg echoArg)
+        public t.Task<EchoResult> AppAsync(EchoArg echoArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<EchoArg, EchoResult, enc.Empty>(echoArg, "api", "/check/app", "app", global::Dropbox.Api.Check.EchoArg.Encoder, global::Dropbox.Api.Check.EchoResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<EchoArg, EchoResult, enc.Empty>(echoArg, "api", "/check/app", "app", global::Dropbox.Api.Check.EchoArg.Encoder, global::Dropbox.Api.Check.EchoResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -68,13 +70,15 @@ namespace Dropbox.Api.Check.Routes
         /// infrastructure is working and that the app key and secret valid.</para>
         /// </summary>
         /// <param name="query">The string that you'd like to be echoed back to you.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<EchoResult> AppAsync(string query = "")
+        public t.Task<EchoResult> AppAsync(string query = "",
+                                           tr.CancellationToken cancellationToken = default)
         {
             var echoArg = new EchoArg(query);
 
-            return this.AppAsync(echoArg);
+            return this.AppAsync(echoArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Check/CheckUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Check/CheckUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Check.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -38,11 +39,12 @@ namespace Dropbox.Api.Check.Routes
         /// infrastructure is working and that the access token is valid.</para>
         /// </summary>
         /// <param name="echoArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<EchoResult> UserAsync(EchoArg echoArg)
+        public t.Task<EchoResult> UserAsync(EchoArg echoArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<EchoArg, EchoResult, enc.Empty>(echoArg, "api", "/check/user", "user", global::Dropbox.Api.Check.EchoArg.Encoder, global::Dropbox.Api.Check.EchoResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<EchoArg, EchoResult, enc.Empty>(echoArg, "api", "/check/user", "user", global::Dropbox.Api.Check.EchoArg.Encoder, global::Dropbox.Api.Check.EchoResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -69,13 +71,15 @@ namespace Dropbox.Api.Check.Routes
         /// infrastructure is working and that the access token is valid.</para>
         /// </summary>
         /// <param name="query">The string that you'd like to be echoed back to you.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<EchoResult> UserAsync(string query = "")
+        public t.Task<EchoResult> UserAsync(string query = "",
+                                            tr.CancellationToken cancellationToken = default)
         {
             var echoArg = new EchoArg(query);
 
-            return this.UserAsync(echoArg);
+            return this.UserAsync(echoArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Contacts/ContactsUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Contacts/ContactsUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Contacts.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -34,10 +35,11 @@ namespace Dropbox.Api.Contacts.Routes
         /// <para>Removes all manually added contacts. You'll still keep contacts who are on
         /// your team or who you imported. New contacts will be added when you share.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
-        public t.Task DeleteManualContactsAsync()
+        public t.Task DeleteManualContactsAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, enc.Empty, enc.Empty>(enc.Empty.Instance, "api", "/contacts/delete_manual_contacts", "user", enc.EmptyEncoder.Instance, enc.EmptyDecoder.Instance, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, enc.Empty, enc.Empty>(enc.Empty.Instance, "api", "/contacts/delete_manual_contacts", "user", enc.EmptyEncoder.Instance, enc.EmptyDecoder.Instance, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -74,13 +76,14 @@ namespace Dropbox.Api.Contacts.Routes
         /// <para>Removes manually added contacts from the given list.</para>
         /// </summary>
         /// <param name="deleteManualContactsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DeleteManualContactsError"/>.</exception>
-        public t.Task DeleteManualContactsBatchAsync(DeleteManualContactsArg deleteManualContactsArg)
+        public t.Task DeleteManualContactsBatchAsync(DeleteManualContactsArg deleteManualContactsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteManualContactsArg, enc.Empty, DeleteManualContactsError>(deleteManualContactsArg, "api", "/contacts/delete_manual_contacts_batch", "user", global::Dropbox.Api.Contacts.DeleteManualContactsArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Contacts.DeleteManualContactsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DeleteManualContactsArg, enc.Empty, DeleteManualContactsError>(deleteManualContactsArg, "api", "/contacts/delete_manual_contacts_batch", "user", global::Dropbox.Api.Contacts.DeleteManualContactsArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Contacts.DeleteManualContactsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -103,15 +106,17 @@ namespace Dropbox.Api.Contacts.Routes
         /// <para>Removes manually added contacts from the given list.</para>
         /// </summary>
         /// <param name="emailAddresses">List of manually added contacts to be deleted.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DeleteManualContactsError"/>.</exception>
-        public t.Task DeleteManualContactsBatchAsync(col.IEnumerable<string> emailAddresses)
+        public t.Task DeleteManualContactsBatchAsync(col.IEnumerable<string> emailAddresses,
+                                                     tr.CancellationToken cancellationToken = default)
         {
             var deleteManualContactsArg = new DeleteManualContactsArg(emailAddresses);
 
-            return this.DeleteManualContactsBatchAsync(deleteManualContactsArg);
+            return this.DeleteManualContactsBatchAsync(deleteManualContactsArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileProperties/FilePropertiesTeamRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileProperties/FilePropertiesTeamRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.FileProperties.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -37,14 +38,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <para>Note: this endpoint will create team-owned templates.</para>
         /// </summary>
         /// <param name="addTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ModifyTemplateError"/>.</exception>
-        public t.Task<AddTemplateResult> TemplatesAddForTeamAsync(AddTemplateArg addTemplateArg)
+        public t.Task<AddTemplateResult> TemplatesAddForTeamAsync(AddTemplateArg addTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddTemplateArg, AddTemplateResult, ModifyTemplateError>(addTemplateArg, "api", "/file_properties/templates/add_for_team", "team", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddTemplateArg, AddTemplateResult, ModifyTemplateError>(addTemplateArg, "api", "/file_properties/templates/add_for_team", "team", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -75,6 +77,7 @@ namespace Dropbox.Api.FileProperties.Routes
         /// be up to 1024 bytes.</param>
         /// <param name="fields">Definitions of the property fields associated with this
         /// template. There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -82,13 +85,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cref="ModifyTemplateError"/>.</exception>
         public t.Task<AddTemplateResult> TemplatesAddForTeamAsync(string name,
                                                                   string description,
-                                                                  col.IEnumerable<PropertyFieldTemplate> fields)
+                                                                  col.IEnumerable<PropertyFieldTemplate> fields,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var addTemplateArg = new AddTemplateArg(name,
                                                     description,
                                                     fields);
 
-            return this.TemplatesAddForTeamAsync(addTemplateArg);
+            return this.TemplatesAddForTeamAsync(addTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -143,14 +147,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <para>Get the schema for a specified template.</para>
         /// </summary>
         /// <param name="getTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<GetTemplateResult> TemplatesGetForTeamAsync(GetTemplateArg getTemplateArg)
+        public t.Task<GetTemplateResult> TemplatesGetForTeamAsync(GetTemplateArg getTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTemplateArg, GetTemplateResult, TemplateError>(getTemplateArg, "api", "/file_properties/templates/get_for_team", "team", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetTemplateArg, GetTemplateResult, TemplateError>(getTemplateArg, "api", "/file_properties/templates/get_for_team", "team", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -177,16 +182,18 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<GetTemplateResult> TemplatesGetForTeamAsync(string templateId)
+        public t.Task<GetTemplateResult> TemplatesGetForTeamAsync(string templateId,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var getTemplateArg = new GetTemplateArg(templateId);
 
-            return this.TemplatesGetForTeamAsync(getTemplateArg);
+            return this.TemplatesGetForTeamAsync(getTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -238,14 +245,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesGetForTeamAsync"
         /// />.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<ListTemplateResult> TemplatesListForTeamAsync()
+        public t.Task<ListTemplateResult> TemplatesListForTeamAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, ListTemplateResult, TemplateError>(enc.Empty.Instance, "api", "/file_properties/templates/list_for_team", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, ListTemplateResult, TemplateError>(enc.Empty.Instance, "api", "/file_properties/templates/list_for_team", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -291,13 +299,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cannot be undone.</para>
         /// </summary>
         /// <param name="removeTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task TemplatesRemoveForTeamAsync(RemoveTemplateArg removeTemplateArg)
+        public t.Task TemplatesRemoveForTeamAsync(RemoveTemplateArg removeTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemoveTemplateArg, enc.Empty, TemplateError>(removeTemplateArg, "api", "/file_properties/templates/remove_for_team", "team", global::Dropbox.Api.FileProperties.RemoveTemplateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemoveTemplateArg, enc.Empty, TemplateError>(removeTemplateArg, "api", "/file_properties/templates/remove_for_team", "team", global::Dropbox.Api.FileProperties.RemoveTemplateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -327,15 +336,17 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task TemplatesRemoveForTeamAsync(string templateId)
+        public t.Task TemplatesRemoveForTeamAsync(string templateId,
+                                                  tr.CancellationToken cancellationToken = default)
         {
             var removeTemplateArg = new RemoveTemplateArg(templateId);
 
-            return this.TemplatesRemoveForTeamAsync(removeTemplateArg);
+            return this.TemplatesRemoveForTeamAsync(removeTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -383,14 +394,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// name, the template description and add optional properties to templates.</para>
         /// </summary>
         /// <param name="updateTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ModifyTemplateError"/>.</exception>
-        public t.Task<UpdateTemplateResult> TemplatesUpdateForTeamAsync(UpdateTemplateArg updateTemplateArg)
+        public t.Task<UpdateTemplateResult> TemplatesUpdateForTeamAsync(UpdateTemplateArg updateTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateTemplateArg, UpdateTemplateResult, ModifyTemplateError>(updateTemplateArg, "api", "/file_properties/templates/update_for_team", "team", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateTemplateArg, UpdateTemplateResult, ModifyTemplateError>(updateTemplateArg, "api", "/file_properties/templates/update_for_team", "team", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -424,6 +436,7 @@ namespace Dropbox.Api.FileProperties.Routes
         /// can be up to 1024 bytes.</param>
         /// <param name="addFields">Property field templates to be added to the group template.
         /// There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -432,14 +445,15 @@ namespace Dropbox.Api.FileProperties.Routes
         public t.Task<UpdateTemplateResult> TemplatesUpdateForTeamAsync(string templateId,
                                                                         string name = null,
                                                                         string description = null,
-                                                                        col.IEnumerable<PropertyFieldTemplate> addFields = null)
+                                                                        col.IEnumerable<PropertyFieldTemplate> addFields = null,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var updateTemplateArg = new UpdateTemplateArg(templateId,
                                                           name,
                                                           description,
                                                           addFields);
 
-            return this.TemplatesUpdateForTeamAsync(updateTemplateArg);
+            return this.TemplatesUpdateForTeamAsync(updateTemplateArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileProperties/FilePropertiesUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileProperties/FilePropertiesUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.FileProperties.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -38,13 +39,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> to create new templates.</para>
         /// </summary>
         /// <param name="addPropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddPropertiesError"/>.</exception>
-        public t.Task PropertiesAddAsync(AddPropertiesArg addPropertiesArg)
+        public t.Task PropertiesAddAsync(AddPropertiesArg addPropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddPropertiesArg, enc.Empty, AddPropertiesError>(addPropertiesArg, "api", "/file_properties/properties/add", "user", global::Dropbox.Api.FileProperties.AddPropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.AddPropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddPropertiesArg, enc.Empty, AddPropertiesError>(addPropertiesArg, "api", "/file_properties/properties/add", "user", global::Dropbox.Api.FileProperties.AddPropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.AddPropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -73,17 +75,19 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="propertyGroups">The property groups which are to be added to a Dropbox
         /// file. No two groups in the input should  refer to the same template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddPropertiesError"/>.</exception>
         public t.Task PropertiesAddAsync(string path,
-                                         col.IEnumerable<PropertyGroup> propertyGroups)
+                                         col.IEnumerable<PropertyGroup> propertyGroups,
+                                         tr.CancellationToken cancellationToken = default)
         {
             var addPropertiesArg = new AddPropertiesArg(path,
                                                         propertyGroups);
 
-            return this.PropertiesAddAsync(addPropertiesArg);
+            return this.PropertiesAddAsync(addPropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -137,13 +141,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> will only delete fields that are explicitly marked for deletion.</para>
         /// </summary>
         /// <param name="overwritePropertyGroupArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="InvalidPropertyGroupError"/>.</exception>
-        public t.Task PropertiesOverwriteAsync(OverwritePropertyGroupArg overwritePropertyGroupArg)
+        public t.Task PropertiesOverwriteAsync(OverwritePropertyGroupArg overwritePropertyGroupArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<OverwritePropertyGroupArg, enc.Empty, InvalidPropertyGroupError>(overwritePropertyGroupArg, "api", "/file_properties/properties/overwrite", "user", global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<OverwritePropertyGroupArg, enc.Empty, InvalidPropertyGroupError>(overwritePropertyGroupArg, "api", "/file_properties/properties/overwrite", "user", global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -175,17 +180,19 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="propertyGroups">The property groups "snapshot" updates to force apply.
         /// No two groups in the input should  refer to the same template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="InvalidPropertyGroupError"/>.</exception>
         public t.Task PropertiesOverwriteAsync(string path,
-                                               col.IEnumerable<PropertyGroup> propertyGroups)
+                                               col.IEnumerable<PropertyGroup> propertyGroups,
+                                               tr.CancellationToken cancellationToken = default)
         {
             var overwritePropertyGroupArg = new OverwritePropertyGroupArg(path,
                                                                           propertyGroups);
 
-            return this.PropertiesOverwriteAsync(overwritePropertyGroupArg);
+            return this.PropertiesOverwriteAsync(overwritePropertyGroupArg, cancellationToken);
         }
 
         /// <summary>
@@ -243,13 +250,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// />.</para>
         /// </summary>
         /// <param name="removePropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemovePropertiesError"/>.</exception>
-        public t.Task PropertiesRemoveAsync(RemovePropertiesArg removePropertiesArg)
+        public t.Task PropertiesRemoveAsync(RemovePropertiesArg removePropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemovePropertiesArg, enc.Empty, RemovePropertiesError>(removePropertiesArg, "api", "/file_properties/properties/remove", "user", global::Dropbox.Api.FileProperties.RemovePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.RemovePropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemovePropertiesArg, enc.Empty, RemovePropertiesError>(removePropertiesArg, "api", "/file_properties/properties/remove", "user", global::Dropbox.Api.FileProperties.RemovePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.RemovePropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -289,17 +297,19 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemovePropertiesError"/>.</exception>
         public t.Task PropertiesRemoveAsync(string path,
-                                            col.IEnumerable<string> propertyTemplateIds)
+                                            col.IEnumerable<string> propertyTemplateIds,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var removePropertiesArg = new RemovePropertiesArg(path,
                                                               propertyTemplateIds);
 
-            return this.PropertiesRemoveAsync(removePropertiesArg);
+            return this.PropertiesRemoveAsync(removePropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -350,14 +360,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <para>Search across property templates for particular property field values.</para>
         /// </summary>
         /// <param name="propertiesSearchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PropertiesSearchError"/>.</exception>
-        public t.Task<PropertiesSearchResult> PropertiesSearchAsync(PropertiesSearchArg propertiesSearchArg)
+        public t.Task<PropertiesSearchResult> PropertiesSearchAsync(PropertiesSearchArg propertiesSearchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<PropertiesSearchArg, PropertiesSearchResult, PropertiesSearchError>(propertiesSearchArg, "api", "/file_properties/properties/search", "user", global::Dropbox.Api.FileProperties.PropertiesSearchArg.Encoder, global::Dropbox.Api.FileProperties.PropertiesSearchResult.Decoder, global::Dropbox.Api.FileProperties.PropertiesSearchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<PropertiesSearchArg, PropertiesSearchResult, PropertiesSearchError>(propertiesSearchArg, "api", "/file_properties/properties/search", "user", global::Dropbox.Api.FileProperties.PropertiesSearchArg.Encoder, global::Dropbox.Api.FileProperties.PropertiesSearchResult.Decoder, global::Dropbox.Api.FileProperties.PropertiesSearchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -382,18 +393,20 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <param name="queries">Queries to search.</param>
         /// <param name="templateFilter">Filter results to contain only properties associated
         /// with these template IDs.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PropertiesSearchError"/>.</exception>
         public t.Task<PropertiesSearchResult> PropertiesSearchAsync(col.IEnumerable<PropertiesSearchQuery> queries,
-                                                                    TemplateFilter templateFilter = null)
+                                                                    TemplateFilter templateFilter = null,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var propertiesSearchArg = new PropertiesSearchArg(queries,
                                                               templateFilter);
 
-            return this.PropertiesSearchAsync(propertiesSearchArg);
+            return this.PropertiesSearchAsync(propertiesSearchArg, cancellationToken);
         }
 
         /// <summary>
@@ -445,14 +458,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// />, use this to paginate through all search results.</para>
         /// </summary>
         /// <param name="propertiesSearchContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PropertiesSearchContinueError"/>.</exception>
-        public t.Task<PropertiesSearchResult> PropertiesSearchContinueAsync(PropertiesSearchContinueArg propertiesSearchContinueArg)
+        public t.Task<PropertiesSearchResult> PropertiesSearchContinueAsync(PropertiesSearchContinueArg propertiesSearchContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<PropertiesSearchContinueArg, PropertiesSearchResult, PropertiesSearchContinueError>(propertiesSearchContinueArg, "api", "/file_properties/properties/search/continue", "user", global::Dropbox.Api.FileProperties.PropertiesSearchContinueArg.Encoder, global::Dropbox.Api.FileProperties.PropertiesSearchResult.Decoder, global::Dropbox.Api.FileProperties.PropertiesSearchContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<PropertiesSearchContinueArg, PropertiesSearchResult, PropertiesSearchContinueError>(propertiesSearchContinueArg, "api", "/file_properties/properties/search/continue", "user", global::Dropbox.Api.FileProperties.PropertiesSearchContinueArg.Encoder, global::Dropbox.Api.FileProperties.PropertiesSearchResult.Decoder, global::Dropbox.Api.FileProperties.PropertiesSearchContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -481,16 +495,18 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesUserRoutes.PropertiesSearchContinueAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PropertiesSearchContinueError"/>.</exception>
-        public t.Task<PropertiesSearchResult> PropertiesSearchContinueAsync(string cursor)
+        public t.Task<PropertiesSearchResult> PropertiesSearchContinueAsync(string cursor,
+                                                                            tr.CancellationToken cancellationToken = default)
         {
             var propertiesSearchContinueArg = new PropertiesSearchContinueArg(cursor);
 
-            return this.PropertiesSearchContinueAsync(propertiesSearchContinueArg);
+            return this.PropertiesSearchContinueAsync(propertiesSearchContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -547,13 +563,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> will delete any fields that are omitted from a property group.</para>
         /// </summary>
         /// <param name="updatePropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UpdatePropertiesError"/>.</exception>
-        public t.Task PropertiesUpdateAsync(UpdatePropertiesArg updatePropertiesArg)
+        public t.Task PropertiesUpdateAsync(UpdatePropertiesArg updatePropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdatePropertiesArg, enc.Empty, UpdatePropertiesError>(updatePropertiesArg, "api", "/file_properties/properties/update", "user", global::Dropbox.Api.FileProperties.UpdatePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.UpdatePropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdatePropertiesArg, enc.Empty, UpdatePropertiesError>(updatePropertiesArg, "api", "/file_properties/properties/update", "user", global::Dropbox.Api.FileProperties.UpdatePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.UpdatePropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -585,17 +602,19 @@ namespace Dropbox.Api.FileProperties.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="updatePropertyGroups">The property groups "delta" updates to
         /// apply.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UpdatePropertiesError"/>.</exception>
         public t.Task PropertiesUpdateAsync(string path,
-                                            col.IEnumerable<PropertyGroupUpdate> updatePropertyGroups)
+                                            col.IEnumerable<PropertyGroupUpdate> updatePropertyGroups,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var updatePropertiesArg = new UpdatePropertiesArg(path,
                                                               updatePropertyGroups);
 
-            return this.PropertiesUpdateAsync(updatePropertiesArg);
+            return this.PropertiesUpdateAsync(updatePropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -645,14 +664,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// admin's behalf.</para>
         /// </summary>
         /// <param name="addTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ModifyTemplateError"/>.</exception>
-        public t.Task<AddTemplateResult> TemplatesAddForUserAsync(AddTemplateArg addTemplateArg)
+        public t.Task<AddTemplateResult> TemplatesAddForUserAsync(AddTemplateArg addTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddTemplateArg, AddTemplateResult, ModifyTemplateError>(addTemplateArg, "api", "/file_properties/templates/add_for_user", "user", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddTemplateArg, AddTemplateResult, ModifyTemplateError>(addTemplateArg, "api", "/file_properties/templates/add_for_user", "user", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -683,6 +703,7 @@ namespace Dropbox.Api.FileProperties.Routes
         /// be up to 1024 bytes.</param>
         /// <param name="fields">Definitions of the property fields associated with this
         /// template. There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -690,13 +711,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cref="ModifyTemplateError"/>.</exception>
         public t.Task<AddTemplateResult> TemplatesAddForUserAsync(string name,
                                                                   string description,
-                                                                  col.IEnumerable<PropertyFieldTemplate> fields)
+                                                                  col.IEnumerable<PropertyFieldTemplate> fields,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var addTemplateArg = new AddTemplateArg(name,
                                                     description,
                                                     fields);
 
-            return this.TemplatesAddForUserAsync(addTemplateArg);
+            return this.TemplatesAddForUserAsync(addTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -752,14 +774,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// team member or admin's behalf.</para>
         /// </summary>
         /// <param name="getTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<GetTemplateResult> TemplatesGetForUserAsync(GetTemplateArg getTemplateArg)
+        public t.Task<GetTemplateResult> TemplatesGetForUserAsync(GetTemplateArg getTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTemplateArg, GetTemplateResult, TemplateError>(getTemplateArg, "api", "/file_properties/templates/get_for_user", "user", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetTemplateArg, GetTemplateResult, TemplateError>(getTemplateArg, "api", "/file_properties/templates/get_for_user", "user", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -787,16 +810,18 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<GetTemplateResult> TemplatesGetForUserAsync(string templateId)
+        public t.Task<GetTemplateResult> TemplatesGetForUserAsync(string templateId,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var getTemplateArg = new GetTemplateArg(templateId);
 
-            return this.TemplatesGetForUserAsync(getTemplateArg);
+            return this.TemplatesGetForUserAsync(getTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -848,14 +873,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesUserRoutes.TemplatesGetForUserAsync"
         /// />. This endpoint can't be called on a team member or admin's behalf.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task<ListTemplateResult> TemplatesListForUserAsync()
+        public t.Task<ListTemplateResult> TemplatesListForUserAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, ListTemplateResult, TemplateError>(enc.Empty.Instance, "api", "/file_properties/templates/list_for_user", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, ListTemplateResult, TemplateError>(enc.Empty.Instance, "api", "/file_properties/templates/list_for_user", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -901,13 +927,14 @@ namespace Dropbox.Api.FileProperties.Routes
         /// cannot be undone.</para>
         /// </summary>
         /// <param name="removeTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task TemplatesRemoveForUserAsync(RemoveTemplateArg removeTemplateArg)
+        public t.Task TemplatesRemoveForUserAsync(RemoveTemplateArg removeTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemoveTemplateArg, enc.Empty, TemplateError>(removeTemplateArg, "api", "/file_properties/templates/remove_for_user", "user", global::Dropbox.Api.FileProperties.RemoveTemplateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemoveTemplateArg, enc.Empty, TemplateError>(removeTemplateArg, "api", "/file_properties/templates/remove_for_user", "user", global::Dropbox.Api.FileProperties.RemoveTemplateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -937,15 +964,17 @@ namespace Dropbox.Api.FileProperties.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TemplateError"/>.</exception>
-        public t.Task TemplatesRemoveForUserAsync(string templateId)
+        public t.Task TemplatesRemoveForUserAsync(string templateId,
+                                                  tr.CancellationToken cancellationToken = default)
         {
             var removeTemplateArg = new RemoveTemplateArg(templateId);
 
-            return this.TemplatesRemoveForUserAsync(removeTemplateArg);
+            return this.TemplatesRemoveForUserAsync(removeTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -994,14 +1023,15 @@ namespace Dropbox.Api.FileProperties.Routes
         /// endpoint can't be called on a team member or admin's behalf.</para>
         /// </summary>
         /// <param name="updateTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ModifyTemplateError"/>.</exception>
-        public t.Task<UpdateTemplateResult> TemplatesUpdateForUserAsync(UpdateTemplateArg updateTemplateArg)
+        public t.Task<UpdateTemplateResult> TemplatesUpdateForUserAsync(UpdateTemplateArg updateTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateTemplateArg, UpdateTemplateResult, ModifyTemplateError>(updateTemplateArg, "api", "/file_properties/templates/update_for_user", "user", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateTemplateArg, UpdateTemplateResult, ModifyTemplateError>(updateTemplateArg, "api", "/file_properties/templates/update_for_user", "user", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1036,6 +1066,7 @@ namespace Dropbox.Api.FileProperties.Routes
         /// can be up to 1024 bytes.</param>
         /// <param name="addFields">Property field templates to be added to the group template.
         /// There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1044,14 +1075,15 @@ namespace Dropbox.Api.FileProperties.Routes
         public t.Task<UpdateTemplateResult> TemplatesUpdateForUserAsync(string templateId,
                                                                         string name = null,
                                                                         string description = null,
-                                                                        col.IEnumerable<PropertyFieldTemplate> addFields = null)
+                                                                        col.IEnumerable<PropertyFieldTemplate> addFields = null,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var updateTemplateArg = new UpdateTemplateArg(templateId,
                                                           name,
                                                           description,
                                                           addFields);
 
-            return this.TemplatesUpdateForUserAsync(updateTemplateArg);
+            return this.TemplatesUpdateForUserAsync(updateTemplateArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileRequests/FileRequestsUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/FileRequests/FileRequestsUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.FileRequests.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -34,14 +35,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Returns the total number of file requests owned by this user. Includes both
         /// open and closed file requests.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CountFileRequestsError"/>.</exception>
-        public t.Task<CountFileRequestsResult> CountAsync()
+        public t.Task<CountFileRequestsResult> CountAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, CountFileRequestsResult, CountFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/count", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.CountFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.CountFileRequestsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, CountFileRequestsResult, CountFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/count", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.CountFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.CountFileRequestsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -83,14 +85,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Creates a file request for this user.</para>
         /// </summary>
         /// <param name="createFileRequestArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateFileRequestError"/>.</exception>
-        public t.Task<FileRequest> CreateAsync(CreateFileRequestArgs createFileRequestArgs)
+        public t.Task<FileRequest> CreateAsync(CreateFileRequestArgs createFileRequestArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateFileRequestArgs, FileRequest, CreateFileRequestError>(createFileRequestArgs, "api", "/file_requests/create", "user", global::Dropbox.Api.FileRequests.CreateFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.CreateFileRequestError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CreateFileRequestArgs, FileRequest, CreateFileRequestError>(createFileRequestArgs, "api", "/file_requests/create", "user", global::Dropbox.Api.FileRequests.CreateFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.CreateFileRequestError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -122,6 +125,7 @@ namespace Dropbox.Api.FileRequests.Routes
         /// request is closed, it will not accept any file submissions, but it can be opened
         /// later.</param>
         /// <param name="description">A description of the file request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -131,7 +135,8 @@ namespace Dropbox.Api.FileRequests.Routes
                                                string destination,
                                                FileRequestDeadline deadline = null,
                                                bool open = true,
-                                               string description = null)
+                                               string description = null,
+                                               tr.CancellationToken cancellationToken = default)
         {
             var createFileRequestArgs = new CreateFileRequestArgs(title,
                                                                   destination,
@@ -139,7 +144,7 @@ namespace Dropbox.Api.FileRequests.Routes
                                                                   open,
                                                                   description);
 
-            return this.CreateAsync(createFileRequestArgs);
+            return this.CreateAsync(createFileRequestArgs, cancellationToken);
         }
 
         /// <summary>
@@ -202,14 +207,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Delete a batch of closed file requests.</para>
         /// </summary>
         /// <param name="deleteFileRequestArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DeleteFileRequestError"/>.</exception>
-        public t.Task<DeleteFileRequestsResult> DeleteAsync(DeleteFileRequestArgs deleteFileRequestArgs)
+        public t.Task<DeleteFileRequestsResult> DeleteAsync(DeleteFileRequestArgs deleteFileRequestArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteFileRequestArgs, DeleteFileRequestsResult, DeleteFileRequestError>(deleteFileRequestArgs, "api", "/file_requests/delete", "user", global::Dropbox.Api.FileRequests.DeleteFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.DeleteFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.DeleteFileRequestError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DeleteFileRequestArgs, DeleteFileRequestsResult, DeleteFileRequestError>(deleteFileRequestArgs, "api", "/file_requests/delete", "user", global::Dropbox.Api.FileRequests.DeleteFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.DeleteFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.DeleteFileRequestError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -232,16 +238,18 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Delete a batch of closed file requests.</para>
         /// </summary>
         /// <param name="ids">List IDs of the file requests to delete.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DeleteFileRequestError"/>.</exception>
-        public t.Task<DeleteFileRequestsResult> DeleteAsync(col.IEnumerable<string> ids)
+        public t.Task<DeleteFileRequestsResult> DeleteAsync(col.IEnumerable<string> ids,
+                                                            tr.CancellationToken cancellationToken = default)
         {
             var deleteFileRequestArgs = new DeleteFileRequestArgs(ids);
 
-            return this.DeleteAsync(deleteFileRequestArgs);
+            return this.DeleteAsync(deleteFileRequestArgs, cancellationToken);
         }
 
         /// <summary>
@@ -286,14 +294,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <summary>
         /// <para>Delete all closed file requests owned by this user.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DeleteAllClosedFileRequestsError"/>.</exception>
-        public t.Task<DeleteAllClosedFileRequestsResult> DeleteAllClosedAsync()
+        public t.Task<DeleteAllClosedFileRequestsResult> DeleteAllClosedAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, DeleteAllClosedFileRequestsResult, DeleteAllClosedFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/delete_all_closed", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.DeleteAllClosedFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.DeleteAllClosedFileRequestsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, DeleteAllClosedFileRequestsResult, DeleteAllClosedFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/delete_all_closed", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.DeleteAllClosedFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.DeleteAllClosedFileRequestsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -336,14 +345,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Returns the specified file request.</para>
         /// </summary>
         /// <param name="getFileRequestArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetFileRequestError"/>.</exception>
-        public t.Task<FileRequest> GetAsync(GetFileRequestArgs getFileRequestArgs)
+        public t.Task<FileRequest> GetAsync(GetFileRequestArgs getFileRequestArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetFileRequestArgs, FileRequest, GetFileRequestError>(getFileRequestArgs, "api", "/file_requests/get", "user", global::Dropbox.Api.FileRequests.GetFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.GetFileRequestError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetFileRequestArgs, FileRequest, GetFileRequestError>(getFileRequestArgs, "api", "/file_requests/get", "user", global::Dropbox.Api.FileRequests.GetFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.GetFileRequestError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -366,16 +376,18 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Returns the specified file request.</para>
         /// </summary>
         /// <param name="id">The ID of the file request to retrieve.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetFileRequestError"/>.</exception>
-        public t.Task<FileRequest> GetAsync(string id)
+        public t.Task<FileRequest> GetAsync(string id,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var getFileRequestArgs = new GetFileRequestArgs(id);
 
-            return this.GetAsync(getFileRequestArgs);
+            return this.GetAsync(getFileRequestArgs, cancellationToken);
         }
 
         /// <summary>
@@ -422,14 +434,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// folder.</para>
         /// </summary>
         /// <param name="listFileRequestsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileRequestsError"/>.</exception>
-        public t.Task<ListFileRequestsV2Result> ListV2Async(ListFileRequestsArg listFileRequestsArg)
+        public t.Task<ListFileRequestsV2Result> ListV2Async(ListFileRequestsArg listFileRequestsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFileRequestsArg, ListFileRequestsV2Result, ListFileRequestsError>(listFileRequestsArg, "api", "/file_requests/list_v2", "user", global::Dropbox.Api.FileRequests.ListFileRequestsArg.Encoder, global::Dropbox.Api.FileRequests.ListFileRequestsV2Result.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFileRequestsArg, ListFileRequestsV2Result, ListFileRequestsError>(listFileRequestsArg, "api", "/file_requests/list_v2", "user", global::Dropbox.Api.FileRequests.ListFileRequestsArg.Encoder, global::Dropbox.Api.FileRequests.ListFileRequestsV2Result.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -455,16 +468,18 @@ namespace Dropbox.Api.FileRequests.Routes
         /// </summary>
         /// <param name="limit">The maximum number of file requests that should be returned per
         /// request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileRequestsError"/>.</exception>
-        public t.Task<ListFileRequestsV2Result> ListV2Async(ulong limit = 1000)
+        public t.Task<ListFileRequestsV2Result> ListV2Async(ulong limit = 1000,
+                                                            tr.CancellationToken cancellationToken = default)
         {
             var listFileRequestsArg = new ListFileRequestsArg(limit);
 
-            return this.ListV2Async(listFileRequestsArg);
+            return this.ListV2Async(listFileRequestsArg, cancellationToken);
         }
 
         /// <summary>
@@ -511,14 +526,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// folder permission, this will only return file requests with destinations in the app
         /// folder.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileRequestsError"/>.</exception>
-        public t.Task<ListFileRequestsResult> ListAsync()
+        public t.Task<ListFileRequestsResult> ListAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, ListFileRequestsResult, ListFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/list", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.ListFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, ListFileRequestsResult, ListFileRequestsError>(enc.Empty.Instance, "api", "/file_requests/list", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileRequests.ListFileRequestsResult.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -567,14 +583,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// />.</para>
         /// </summary>
         /// <param name="listFileRequestsContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileRequestsContinueError"/>.</exception>
-        public t.Task<ListFileRequestsV2Result> ListContinueAsync(ListFileRequestsContinueArg listFileRequestsContinueArg)
+        public t.Task<ListFileRequestsV2Result> ListContinueAsync(ListFileRequestsContinueArg listFileRequestsContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFileRequestsContinueArg, ListFileRequestsV2Result, ListFileRequestsContinueError>(listFileRequestsContinueArg, "api", "/file_requests/list/continue", "user", global::Dropbox.Api.FileRequests.ListFileRequestsContinueArg.Encoder, global::Dropbox.Api.FileRequests.ListFileRequestsV2Result.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFileRequestsContinueArg, ListFileRequestsV2Result, ListFileRequestsContinueError>(listFileRequestsContinueArg, "api", "/file_requests/list/continue", "user", global::Dropbox.Api.FileRequests.ListFileRequestsContinueArg.Encoder, global::Dropbox.Api.FileRequests.ListFileRequestsV2Result.Decoder, global::Dropbox.Api.FileRequests.ListFileRequestsContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -605,16 +622,18 @@ namespace Dropbox.Api.FileRequests.Routes
         /// </summary>
         /// <param name="cursor">The cursor returned by the previous API call specified in the
         /// endpoint description.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileRequestsContinueError"/>.</exception>
-        public t.Task<ListFileRequestsV2Result> ListContinueAsync(string cursor)
+        public t.Task<ListFileRequestsV2Result> ListContinueAsync(string cursor,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listFileRequestsContinueArg = new ListFileRequestsContinueArg(cursor);
 
-            return this.ListContinueAsync(listFileRequestsContinueArg);
+            return this.ListContinueAsync(listFileRequestsContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -661,14 +680,15 @@ namespace Dropbox.Api.FileRequests.Routes
         /// <para>Update a file request.</para>
         /// </summary>
         /// <param name="updateFileRequestArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UpdateFileRequestError"/>.</exception>
-        public t.Task<FileRequest> UpdateAsync(UpdateFileRequestArgs updateFileRequestArgs)
+        public t.Task<FileRequest> UpdateAsync(UpdateFileRequestArgs updateFileRequestArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateFileRequestArgs, FileRequest, UpdateFileRequestError>(updateFileRequestArgs, "api", "/file_requests/update", "user", global::Dropbox.Api.FileRequests.UpdateFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.UpdateFileRequestError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateFileRequestArgs, FileRequest, UpdateFileRequestError>(updateFileRequestArgs, "api", "/file_requests/update", "user", global::Dropbox.Api.FileRequests.UpdateFileRequestArgs.Encoder, global::Dropbox.Api.FileRequests.FileRequest.Decoder, global::Dropbox.Api.FileRequests.UpdateFileRequestError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -699,6 +719,7 @@ namespace Dropbox.Api.FileRequests.Routes
         /// set by Professional and Business accounts.</param>
         /// <param name="open">Whether to set this file request as open or closed.</param>
         /// <param name="description">The description of the file request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -709,7 +730,8 @@ namespace Dropbox.Api.FileRequests.Routes
                                                string destination = null,
                                                UpdateFileRequestDeadline deadline = null,
                                                bool? open = null,
-                                               string description = null)
+                                               string description = null,
+                                               tr.CancellationToken cancellationToken = default)
         {
             var updateFileRequestArgs = new UpdateFileRequestArgs(id,
                                                                   title,
@@ -718,7 +740,7 @@ namespace Dropbox.Api.FileRequests.Routes
                                                                   open,
                                                                   description);
 
-            return this.UpdateAsync(updateFileRequestArgs);
+            return this.UpdateAsync(updateFileRequestArgs, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Files/FilesAppRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Files/FilesAppRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Files.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -33,14 +34,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Get a thumbnail for a file.</para>
         /// </summary>
         /// <param name="thumbnailV2Arg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ThumbnailV2Error"/>.</exception>
-        public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(ThumbnailV2Arg thumbnailV2Arg)
+        public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(ThumbnailV2Arg thumbnailV2Arg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<ThumbnailV2Arg, PreviewResult, ThumbnailV2Error>(thumbnailV2Arg, "content", "/files/get_thumbnail_v2", "app", global::Dropbox.Api.Files.ThumbnailV2Arg.Encoder, global::Dropbox.Api.Files.PreviewResult.Decoder, global::Dropbox.Api.Files.ThumbnailV2Error.Decoder);
+            return this.Transport.SendDownloadRequestAsync<ThumbnailV2Arg, PreviewResult, ThumbnailV2Error>(thumbnailV2Arg, "content", "/files/get_thumbnail_v2", "app", global::Dropbox.Api.Files.ThumbnailV2Arg.Encoder, global::Dropbox.Api.Files.PreviewResult.Decoder, global::Dropbox.Api.Files.ThumbnailV2Error.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -71,6 +73,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="size">The size for the thumbnail image.</param>
         /// <param name="mode">How to resize and crop the image to achieve the desired
         /// size.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -79,14 +82,15 @@ namespace Dropbox.Api.Files.Routes
         public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(PathOrLink resource,
                                                                                 ThumbnailFormat format = null,
                                                                                 ThumbnailSize size = null,
-                                                                                ThumbnailMode mode = null)
+                                                                                ThumbnailMode mode = null,
+                                                                                tr.CancellationToken cancellationToken = default)
         {
             var thumbnailV2Arg = new ThumbnailV2Arg(resource,
                                                     format,
                                                     size,
                                                     mode);
 
-            return this.GetThumbnailV2Async(thumbnailV2Arg);
+            return this.GetThumbnailV2Async(thumbnailV2Arg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Files/FilesUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Files/FilesUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Files.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -36,15 +37,16 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Note: Metadata for the root folder is unsupported.</para>
         /// </summary>
         /// <param name="alphaGetMetadataArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AlphaGetMetadataError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use GetMetadataAsync instead.")]
-        public t.Task<Metadata> AlphaGetMetadataAsync(AlphaGetMetadataArg alphaGetMetadataArg)
+        public t.Task<Metadata> AlphaGetMetadataAsync(AlphaGetMetadataArg alphaGetMetadataArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AlphaGetMetadataArg, Metadata, AlphaGetMetadataError>(alphaGetMetadataArg, "api", "/files/alpha/get_metadata", "user", global::Dropbox.Api.Files.AlphaGetMetadataArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.AlphaGetMetadataError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AlphaGetMetadataArg, Metadata, AlphaGetMetadataError>(alphaGetMetadataArg, "api", "/files/alpha/get_metadata", "user", global::Dropbox.Api.Files.AlphaGetMetadataArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.AlphaGetMetadataError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -85,6 +87,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="includePropertyTemplates">If set to a valid list of template IDs, <see
         /// cref="Dropbox.Api.Files.FileMetadata.PropertyGroups" /> is set for files with
         /// custom properties.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -96,7 +99,8 @@ namespace Dropbox.Api.Files.Routes
                                                       bool includeDeleted = false,
                                                       bool includeHasExplicitSharedMembers = false,
                                                       global::Dropbox.Api.FileProperties.TemplateFilterBase includePropertyGroups = null,
-                                                      col.IEnumerable<string> includePropertyTemplates = null)
+                                                      col.IEnumerable<string> includePropertyTemplates = null,
+                                                      tr.CancellationToken cancellationToken = default)
         {
             var alphaGetMetadataArg = new AlphaGetMetadataArg(path,
                                                               includeMediaInfo,
@@ -105,7 +109,7 @@ namespace Dropbox.Api.Files.Routes
                                                               includePropertyGroups,
                                                               includePropertyTemplates);
 
-            return this.AlphaGetMetadataAsync(alphaGetMetadataArg);
+            return this.AlphaGetMetadataAsync(alphaGetMetadataArg, cancellationToken);
         }
 
         /// <summary>
@@ -184,15 +188,16 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="commitInfoWithProperties">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadErrorWithProperties"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use AlphaUploadAsync instead.")]
-        public t.Task<FileMetadata> AlphaUploadAsync(CommitInfoWithProperties commitInfoWithProperties, io.Stream body)
+        public t.Task<FileMetadata> AlphaUploadAsync(CommitInfoWithProperties commitInfoWithProperties, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<CommitInfoWithProperties, FileMetadata, UploadErrorWithProperties>(commitInfoWithProperties, body, "content", "/files/alpha/upload", "user", global::Dropbox.Api.Files.CommitInfoWithProperties.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadErrorWithProperties.Decoder);
+            return this.Transport.SendUploadRequestAsync<CommitInfoWithProperties, FileMetadata, UploadErrorWithProperties>(commitInfoWithProperties, body, "content", "/files/alpha/upload", "user", global::Dropbox.Api.Files.CommitInfoWithProperties.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadErrorWithProperties.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -243,6 +248,7 @@ namespace Dropbox.Api.Files.Routes
         /// deleted. This also forces a conflict even when the target path refers to a file
         /// with identical contents.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -256,7 +262,8 @@ namespace Dropbox.Api.Files.Routes
                                                      bool mute = false,
                                                      col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups = null,
                                                      bool strictConflict = false,
-                                                     io.Stream body = null)
+                                                     io.Stream body = null,
+                                                     tr.CancellationToken cancellationToken = default)
         {
             var commitInfoWithProperties = new CommitInfoWithProperties(path,
                                                                         mode,
@@ -266,7 +273,7 @@ namespace Dropbox.Api.Files.Routes
                                                                         propertyGroups,
                                                                         strictConflict);
 
-            return this.AlphaUploadAsync(commitInfoWithProperties, body);
+            return this.AlphaUploadAsync(commitInfoWithProperties, body, cancellationToken);
         }
 
         /// <summary>
@@ -349,14 +356,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>If the source path is a folder all its contents will be copied.</para>
         /// </summary>
         /// <param name="relocationArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelocationError"/>.</exception>
-        public t.Task<RelocationResult> CopyV2Async(RelocationArg relocationArg)
+        public t.Task<RelocationResult> CopyV2Async(RelocationArg relocationArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationArg, RelocationResult, RelocationError>(relocationArg, "api", "/files/copy_v2", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.RelocationResult.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelocationArg, RelocationResult, RelocationError>(relocationArg, "api", "/files/copy_v2", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.RelocationResult.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -387,6 +395,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -396,7 +405,8 @@ namespace Dropbox.Api.Files.Routes
                                                     string toPath,
                                                     bool allowSharedFolder = false,
                                                     bool autorename = false,
-                                                    bool allowOwnershipTransfer = false)
+                                                    bool allowOwnershipTransfer = false,
+                                                    tr.CancellationToken cancellationToken = default)
         {
             var relocationArg = new RelocationArg(fromPath,
                                                   toPath,
@@ -404,7 +414,7 @@ namespace Dropbox.Api.Files.Routes
                                                   autorename,
                                                   allowOwnershipTransfer);
 
-            return this.CopyV2Async(relocationArg);
+            return this.CopyV2Async(relocationArg, cancellationToken);
         }
 
         /// <summary>
@@ -465,15 +475,16 @@ namespace Dropbox.Api.Files.Routes
         /// <para>If the source path is a folder all its contents will be copied.</para>
         /// </summary>
         /// <param name="relocationArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelocationError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CopyV2Async instead.")]
-        public t.Task<Metadata> CopyAsync(RelocationArg relocationArg)
+        public t.Task<Metadata> CopyAsync(RelocationArg relocationArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationArg, Metadata, RelocationError>(relocationArg, "api", "/files/copy", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelocationArg, Metadata, RelocationError>(relocationArg, "api", "/files/copy", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -505,6 +516,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -515,7 +527,8 @@ namespace Dropbox.Api.Files.Routes
                                           string toPath,
                                           bool allowSharedFolder = false,
                                           bool autorename = false,
-                                          bool allowOwnershipTransfer = false)
+                                          bool allowOwnershipTransfer = false,
+                                          tr.CancellationToken cancellationToken = default)
         {
             var relocationArg = new RelocationArg(fromPath,
                                                   toPath,
@@ -523,7 +536,7 @@ namespace Dropbox.Api.Files.Routes
                                                   autorename,
                                                   allowOwnershipTransfer);
 
-            return this.CopyAsync(relocationArg);
+            return this.CopyAsync(relocationArg, cancellationToken);
         }
 
         /// <summary>
@@ -595,11 +608,12 @@ namespace Dropbox.Api.Files.Routes
         /// the job status.</para>
         /// </summary>
         /// <param name="relocationBatchArgBase">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<RelocationBatchV2Launch> CopyBatchV2Async(RelocationBatchArgBase relocationBatchArgBase)
+        public t.Task<RelocationBatchV2Launch> CopyBatchV2Async(RelocationBatchArgBase relocationBatchArgBase, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationBatchArgBase, RelocationBatchV2Launch, enc.Empty>(relocationBatchArgBase, "api", "/files/copy_batch_v2", "user", global::Dropbox.Api.Files.RelocationBatchArgBase.Encoder, global::Dropbox.Api.Files.RelocationBatchV2Launch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<RelocationBatchArgBase, RelocationBatchV2Launch, enc.Empty>(relocationBatchArgBase, "api", "/files/copy_batch_v2", "user", global::Dropbox.Api.Files.RelocationBatchArgBase.Encoder, global::Dropbox.Api.Files.RelocationBatchV2Launch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -635,15 +649,17 @@ namespace Dropbox.Api.Files.Routes
         /// cref="RelocationPath" />.</param>
         /// <param name="autorename">If there's a conflict with any file, have the Dropbox
         /// server try to autorename that file to avoid the conflict.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<RelocationBatchV2Launch> CopyBatchV2Async(col.IEnumerable<RelocationPath> entries,
-                                                                bool autorename = false)
+                                                                bool autorename = false,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var relocationBatchArgBase = new RelocationBatchArgBase(entries,
                                                                     autorename);
 
-            return this.CopyBatchV2Async(relocationBatchArgBase);
+            return this.CopyBatchV2Async(relocationBatchArgBase, cancellationToken);
         }
 
         /// <summary>
@@ -696,12 +712,13 @@ namespace Dropbox.Api.Files.Routes
         /// job status.</para>
         /// </summary>
         /// <param name="relocationBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated, please use CopyBatchV2Async instead.")]
-        public t.Task<RelocationBatchLaunch> CopyBatchAsync(RelocationBatchArg relocationBatchArg)
+        public t.Task<RelocationBatchLaunch> CopyBatchAsync(RelocationBatchArg relocationBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationBatchArg, RelocationBatchLaunch, enc.Empty>(relocationBatchArg, "api", "/files/copy_batch", "user", global::Dropbox.Api.Files.RelocationBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<RelocationBatchArg, RelocationBatchLaunch, enc.Empty>(relocationBatchArg, "api", "/files/copy_batch", "user", global::Dropbox.Api.Files.RelocationBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -737,20 +754,22 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated, please use CopyBatchV2Async instead.")]
         public t.Task<RelocationBatchLaunch> CopyBatchAsync(col.IEnumerable<RelocationPath> entries,
                                                             bool autorename = false,
                                                             bool allowSharedFolder = false,
-                                                            bool allowOwnershipTransfer = false)
+                                                            bool allowOwnershipTransfer = false,
+                                                            tr.CancellationToken cancellationToken = default)
         {
             var relocationBatchArg = new RelocationBatchArg(entries,
                                                             autorename,
                                                             allowSharedFolder,
                                                             allowOwnershipTransfer);
 
-            return this.CopyBatchAsync(relocationBatchArg);
+            return this.CopyBatchAsync(relocationBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -810,14 +829,15 @@ namespace Dropbox.Api.Files.Routes
         /// list of results for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RelocationBatchV2JobStatus> CopyBatchCheckV2Async(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<RelocationBatchV2JobStatus> CopyBatchCheckV2Async(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchV2JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/copy_batch/check_v2", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchV2JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/copy_batch/check_v2", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -843,16 +863,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RelocationBatchV2JobStatus> CopyBatchCheckV2Async(string asyncJobId)
+        public t.Task<RelocationBatchV2JobStatus> CopyBatchCheckV2Async(string asyncJobId,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CopyBatchCheckV2Async(pollArg);
+            return this.CopyBatchCheckV2Async(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -901,15 +923,16 @@ namespace Dropbox.Api.Files.Routes
         /// returns list of results for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CopyBatchCheckV2Async instead.")]
-        public t.Task<RelocationBatchJobStatus> CopyBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<RelocationBatchJobStatus> CopyBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/copy_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/copy_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -936,17 +959,19 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CopyBatchCheckV2Async instead.")]
-        public t.Task<RelocationBatchJobStatus> CopyBatchCheckAsync(string asyncJobId)
+        public t.Task<RelocationBatchJobStatus> CopyBatchCheckAsync(string asyncJobId,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CopyBatchCheckAsync(pollArg);
+            return this.CopyBatchCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -997,14 +1022,15 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.CopyReferenceSaveAsync" />.</para>
         /// </summary>
         /// <param name="getCopyReferenceArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetCopyReferenceError"/>.</exception>
-        public t.Task<GetCopyReferenceResult> CopyReferenceGetAsync(GetCopyReferenceArg getCopyReferenceArg)
+        public t.Task<GetCopyReferenceResult> CopyReferenceGetAsync(GetCopyReferenceArg getCopyReferenceArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetCopyReferenceArg, GetCopyReferenceResult, GetCopyReferenceError>(getCopyReferenceArg, "api", "/files/copy_reference/get", "user", global::Dropbox.Api.Files.GetCopyReferenceArg.Encoder, global::Dropbox.Api.Files.GetCopyReferenceResult.Decoder, global::Dropbox.Api.Files.GetCopyReferenceError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetCopyReferenceArg, GetCopyReferenceResult, GetCopyReferenceError>(getCopyReferenceArg, "api", "/files/copy_reference/get", "user", global::Dropbox.Api.Files.GetCopyReferenceArg.Encoder, global::Dropbox.Api.Files.GetCopyReferenceResult.Decoder, global::Dropbox.Api.Files.GetCopyReferenceError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1030,16 +1056,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="path">The path to the file or folder you want to get a copy reference
         /// to.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetCopyReferenceError"/>.</exception>
-        public t.Task<GetCopyReferenceResult> CopyReferenceGetAsync(string path)
+        public t.Task<GetCopyReferenceResult> CopyReferenceGetAsync(string path,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var getCopyReferenceArg = new GetCopyReferenceArg(path);
 
-            return this.CopyReferenceGetAsync(getCopyReferenceArg);
+            return this.CopyReferenceGetAsync(getCopyReferenceArg, cancellationToken);
         }
 
         /// <summary>
@@ -1088,14 +1116,15 @@ namespace Dropbox.Api.Files.Routes
         /// user's Dropbox.</para>
         /// </summary>
         /// <param name="saveCopyReferenceArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SaveCopyReferenceError"/>.</exception>
-        public t.Task<SaveCopyReferenceResult> CopyReferenceSaveAsync(SaveCopyReferenceArg saveCopyReferenceArg)
+        public t.Task<SaveCopyReferenceResult> CopyReferenceSaveAsync(SaveCopyReferenceArg saveCopyReferenceArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SaveCopyReferenceArg, SaveCopyReferenceResult, SaveCopyReferenceError>(saveCopyReferenceArg, "api", "/files/copy_reference/save", "user", global::Dropbox.Api.Files.SaveCopyReferenceArg.Encoder, global::Dropbox.Api.Files.SaveCopyReferenceResult.Decoder, global::Dropbox.Api.Files.SaveCopyReferenceError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SaveCopyReferenceArg, SaveCopyReferenceResult, SaveCopyReferenceError>(saveCopyReferenceArg, "api", "/files/copy_reference/save", "user", global::Dropbox.Api.Files.SaveCopyReferenceArg.Encoder, global::Dropbox.Api.Files.SaveCopyReferenceResult.Decoder, global::Dropbox.Api.Files.SaveCopyReferenceError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1122,18 +1151,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="copyReference">A copy reference returned by <see
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.CopyReferenceGetAsync" />.</param>
         /// <param name="path">Path in the user's Dropbox that is the destination.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SaveCopyReferenceError"/>.</exception>
         public t.Task<SaveCopyReferenceResult> CopyReferenceSaveAsync(string copyReference,
-                                                                      string path)
+                                                                      string path,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var saveCopyReferenceArg = new SaveCopyReferenceArg(copyReference,
                                                                 path);
 
-            return this.CopyReferenceSaveAsync(saveCopyReferenceArg);
+            return this.CopyReferenceSaveAsync(saveCopyReferenceArg, cancellationToken);
         }
 
         /// <summary>
@@ -1183,14 +1214,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Create a folder at a given path.</para>
         /// </summary>
         /// <param name="createFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateFolderError"/>.</exception>
-        public t.Task<CreateFolderResult> CreateFolderV2Async(CreateFolderArg createFolderArg)
+        public t.Task<CreateFolderResult> CreateFolderV2Async(CreateFolderArg createFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateFolderArg, CreateFolderResult, CreateFolderError>(createFolderArg, "api", "/files/create_folder_v2", "user", global::Dropbox.Api.Files.CreateFolderArg.Encoder, global::Dropbox.Api.Files.CreateFolderResult.Decoder, global::Dropbox.Api.Files.CreateFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CreateFolderArg, CreateFolderResult, CreateFolderError>(createFolderArg, "api", "/files/create_folder_v2", "user", global::Dropbox.Api.Files.CreateFolderArg.Encoder, global::Dropbox.Api.Files.CreateFolderResult.Decoder, global::Dropbox.Api.Files.CreateFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1215,18 +1247,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">Path in the user's Dropbox to create.</param>
         /// <param name="autorename">If there's a conflict, have the Dropbox server try to
         /// autorename the folder to avoid the conflict.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateFolderError"/>.</exception>
         public t.Task<CreateFolderResult> CreateFolderV2Async(string path,
-                                                              bool autorename = false)
+                                                              bool autorename = false,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var createFolderArg = new CreateFolderArg(path,
                                                       autorename);
 
-            return this.CreateFolderV2Async(createFolderArg);
+            return this.CreateFolderV2Async(createFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -1276,15 +1310,16 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Create a folder at a given path.</para>
         /// </summary>
         /// <param name="createFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateFolderError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CreateFolderV2Async instead.")]
-        public t.Task<FolderMetadata> CreateFolderAsync(CreateFolderArg createFolderArg)
+        public t.Task<FolderMetadata> CreateFolderAsync(CreateFolderArg createFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateFolderArg, FolderMetadata, CreateFolderError>(createFolderArg, "api", "/files/create_folder", "user", global::Dropbox.Api.Files.CreateFolderArg.Encoder, global::Dropbox.Api.Files.FolderMetadata.Decoder, global::Dropbox.Api.Files.CreateFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CreateFolderArg, FolderMetadata, CreateFolderError>(createFolderArg, "api", "/files/create_folder", "user", global::Dropbox.Api.Files.CreateFolderArg.Encoder, global::Dropbox.Api.Files.FolderMetadata.Decoder, global::Dropbox.Api.Files.CreateFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1310,6 +1345,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">Path in the user's Dropbox to create.</param>
         /// <param name="autorename">If there's a conflict, have the Dropbox server try to
         /// autorename the folder to avoid the conflict.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1317,12 +1353,13 @@ namespace Dropbox.Api.Files.Routes
         /// cref="CreateFolderError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CreateFolderV2Async instead.")]
         public t.Task<FolderMetadata> CreateFolderAsync(string path,
-                                                        bool autorename = false)
+                                                        bool autorename = false,
+                                                        tr.CancellationToken cancellationToken = default)
         {
             var createFolderArg = new CreateFolderArg(path,
                                                       autorename);
 
-            return this.CreateFolderAsync(createFolderArg);
+            return this.CreateFolderAsync(createFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -1381,11 +1418,12 @@ namespace Dropbox.Api.Files.Routes
         /// check the job status.</para>
         /// </summary>
         /// <param name="createFolderBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<CreateFolderBatchLaunch> CreateFolderBatchAsync(CreateFolderBatchArg createFolderBatchArg)
+        public t.Task<CreateFolderBatchLaunch> CreateFolderBatchAsync(CreateFolderBatchArg createFolderBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateFolderBatchArg, CreateFolderBatchLaunch, enc.Empty>(createFolderBatchArg, "api", "/files/create_folder_batch", "user", global::Dropbox.Api.Files.CreateFolderBatchArg.Encoder, global::Dropbox.Api.Files.CreateFolderBatchLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<CreateFolderBatchArg, CreateFolderBatchLaunch, enc.Empty>(createFolderBatchArg, "api", "/files/create_folder_batch", "user", global::Dropbox.Api.Files.CreateFolderBatchArg.Encoder, global::Dropbox.Api.Files.CreateFolderBatchLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -1420,17 +1458,19 @@ namespace Dropbox.Api.Files.Routes
         /// autorename the folder to avoid the conflict.</param>
         /// <param name="forceAsync">Whether to force the create to happen
         /// asynchronously.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<CreateFolderBatchLaunch> CreateFolderBatchAsync(col.IEnumerable<string> paths,
                                                                       bool autorename = false,
-                                                                      bool forceAsync = false)
+                                                                      bool forceAsync = false,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var createFolderBatchArg = new CreateFolderBatchArg(paths,
                                                                 autorename,
                                                                 forceAsync);
 
-            return this.CreateFolderBatchAsync(createFolderBatchArg);
+            return this.CreateFolderBatchAsync(createFolderBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -1484,14 +1524,15 @@ namespace Dropbox.Api.Files.Routes
         /// success, it returns list of result for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<CreateFolderBatchJobStatus> CreateFolderBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<CreateFolderBatchJobStatus> CreateFolderBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, CreateFolderBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/create_folder_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.CreateFolderBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, CreateFolderBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/create_folder_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.CreateFolderBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1517,16 +1558,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<CreateFolderBatchJobStatus> CreateFolderBatchCheckAsync(string asyncJobId)
+        public t.Task<CreateFolderBatchJobStatus> CreateFolderBatchCheckAsync(string asyncJobId,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CreateFolderBatchCheckAsync(pollArg);
+            return this.CreateFolderBatchCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -1578,13 +1621,14 @@ namespace Dropbox.Api.Files.Routes
         /// cref="DeletedMetadata" /> object.</para>
         /// </summary>
         /// <param name="deleteArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
-        public t.Task<DeleteResult> DeleteV2Async(DeleteArg deleteArg)
+        public t.Task<DeleteResult> DeleteV2Async(DeleteArg deleteArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteArg, DeleteResult, DeleteError>(deleteArg, "api", "/files/delete_v2", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, global::Dropbox.Api.Files.DeleteResult.Decoder, global::Dropbox.Api.Files.DeleteError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DeleteArg, DeleteResult, DeleteError>(deleteArg, "api", "/files/delete_v2", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, global::Dropbox.Api.Files.DeleteResult.Decoder, global::Dropbox.Api.Files.DeleteError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1614,17 +1658,19 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">Path in the user's Dropbox to delete.</param>
         /// <param name="parentRev">Perform delete if given "rev" matches the existing file's
         /// latest "rev". This field does not support deleting a folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
         public t.Task<DeleteResult> DeleteV2Async(string path,
-                                                  string parentRev = null)
+                                                  string parentRev = null,
+                                                  tr.CancellationToken cancellationToken = default)
         {
             var deleteArg = new DeleteArg(path,
                                           parentRev);
 
-            return this.DeleteV2Async(deleteArg);
+            return this.DeleteV2Async(deleteArg, cancellationToken);
         }
 
         /// <summary>
@@ -1678,14 +1724,15 @@ namespace Dropbox.Api.Files.Routes
         /// cref="DeletedMetadata" /> object.</para>
         /// </summary>
         /// <param name="deleteArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use DeleteV2Async instead.")]
-        public t.Task<Metadata> DeleteAsync(DeleteArg deleteArg)
+        public t.Task<Metadata> DeleteAsync(DeleteArg deleteArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteArg, Metadata, DeleteError>(deleteArg, "api", "/files/delete", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.DeleteError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DeleteArg, Metadata, DeleteError>(deleteArg, "api", "/files/delete", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.DeleteError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1716,18 +1763,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">Path in the user's Dropbox to delete.</param>
         /// <param name="parentRev">Perform delete if given "rev" matches the existing file's
         /// latest "rev". This field does not support deleting a folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use DeleteV2Async instead.")]
         public t.Task<Metadata> DeleteAsync(string path,
-                                            string parentRev = null)
+                                            string parentRev = null,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var deleteArg = new DeleteArg(path,
                                           parentRev);
 
-            return this.DeleteAsync(deleteArg);
+            return this.DeleteAsync(deleteArg, cancellationToken);
         }
 
         /// <summary>
@@ -1782,11 +1831,12 @@ namespace Dropbox.Api.Files.Routes
         /// the job status.</para>
         /// </summary>
         /// <param name="deleteBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<DeleteBatchLaunch> DeleteBatchAsync(DeleteBatchArg deleteBatchArg)
+        public t.Task<DeleteBatchLaunch> DeleteBatchAsync(DeleteBatchArg deleteBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteBatchArg, DeleteBatchLaunch, enc.Empty>(deleteBatchArg, "api", "/files/delete_batch", "user", global::Dropbox.Api.Files.DeleteBatchArg.Encoder, global::Dropbox.Api.Files.DeleteBatchLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<DeleteBatchArg, DeleteBatchLaunch, enc.Empty>(deleteBatchArg, "api", "/files/delete_batch", "user", global::Dropbox.Api.Files.DeleteBatchArg.Encoder, global::Dropbox.Api.Files.DeleteBatchLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -1813,13 +1863,15 @@ namespace Dropbox.Api.Files.Routes
         /// the job status.</para>
         /// </summary>
         /// <param name="entries">The entries</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<DeleteBatchLaunch> DeleteBatchAsync(col.IEnumerable<DeleteArg> entries)
+        public t.Task<DeleteBatchLaunch> DeleteBatchAsync(col.IEnumerable<DeleteArg> entries,
+                                                          tr.CancellationToken cancellationToken = default)
         {
             var deleteBatchArg = new DeleteBatchArg(entries);
 
-            return this.DeleteBatchAsync(deleteBatchArg);
+            return this.DeleteBatchAsync(deleteBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -1864,14 +1916,15 @@ namespace Dropbox.Api.Files.Routes
         /// returns list of result for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<DeleteBatchJobStatus> DeleteBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<DeleteBatchJobStatus> DeleteBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, DeleteBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/delete_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.DeleteBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, DeleteBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/delete_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.DeleteBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1897,16 +1950,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<DeleteBatchJobStatus> DeleteBatchCheckAsync(string asyncJobId)
+        public t.Task<DeleteBatchJobStatus> DeleteBatchCheckAsync(string asyncJobId,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.DeleteBatchCheckAsync(pollArg);
+            return this.DeleteBatchCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -1953,14 +2008,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Download a file from a user's Dropbox.</para>
         /// </summary>
         /// <param name="downloadArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DownloadError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<FileMetadata>> DownloadAsync(DownloadArg downloadArg)
+        public t.Task<enc.IDownloadResponse<FileMetadata>> DownloadAsync(DownloadArg downloadArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<DownloadArg, FileMetadata, DownloadError>(downloadArg, "content", "/files/download", "user", global::Dropbox.Api.Files.DownloadArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.DownloadError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<DownloadArg, FileMetadata, DownloadError>(downloadArg, "content", "/files/download", "user", global::Dropbox.Api.Files.DownloadArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.DownloadError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1985,18 +2041,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">The path of the file to download.</param>
         /// <param name="rev">Please specify revision in <paramref name="path" />
         /// instead.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DownloadError"/>.</exception>
         public t.Task<enc.IDownloadResponse<FileMetadata>> DownloadAsync(string path,
-                                                                         string rev = null)
+                                                                         string rev = null,
+                                                                         tr.CancellationToken cancellationToken = default)
         {
             var downloadArg = new DownloadArg(path,
                                               rev);
 
-            return this.DownloadAsync(downloadArg);
+            return this.DownloadAsync(downloadArg, cancellationToken);
         }
 
         /// <summary>
@@ -2048,14 +2106,15 @@ namespace Dropbox.Api.Files.Routes
         /// a single file. Any single file must be less than 4GB in size.</para>
         /// </summary>
         /// <param name="downloadZipArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DownloadZipError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<DownloadZipResult>> DownloadZipAsync(DownloadZipArg downloadZipArg)
+        public t.Task<enc.IDownloadResponse<DownloadZipResult>> DownloadZipAsync(DownloadZipArg downloadZipArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<DownloadZipArg, DownloadZipResult, DownloadZipError>(downloadZipArg, "content", "/files/download_zip", "user", global::Dropbox.Api.Files.DownloadZipArg.Encoder, global::Dropbox.Api.Files.DownloadZipResult.Decoder, global::Dropbox.Api.Files.DownloadZipError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<DownloadZipArg, DownloadZipResult, DownloadZipError>(downloadZipArg, "content", "/files/download_zip", "user", global::Dropbox.Api.Files.DownloadZipArg.Encoder, global::Dropbox.Api.Files.DownloadZipResult.Decoder, global::Dropbox.Api.Files.DownloadZipError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2080,16 +2139,18 @@ namespace Dropbox.Api.Files.Routes
         /// a single file. Any single file must be less than 4GB in size.</para>
         /// </summary>
         /// <param name="path">The path of the folder to download.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DownloadZipError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<DownloadZipResult>> DownloadZipAsync(string path)
+        public t.Task<enc.IDownloadResponse<DownloadZipResult>> DownloadZipAsync(string path,
+                                                                                 tr.CancellationToken cancellationToken = default)
         {
             var downloadZipArg = new DownloadZipArg(path);
 
-            return this.DownloadZipAsync(downloadZipArg);
+            return this.DownloadZipAsync(downloadZipArg, cancellationToken);
         }
 
         /// <summary>
@@ -2138,13 +2199,14 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.ExportInfo.ExportAs" /> populated.</para>
         /// </summary>
         /// <param name="exportArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="ExportError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<ExportResult>> ExportAsync(ExportArg exportArg)
+        public t.Task<enc.IDownloadResponse<ExportResult>> ExportAsync(ExportArg exportArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<ExportArg, ExportResult, ExportError>(exportArg, "content", "/files/export", "user", global::Dropbox.Api.Files.ExportArg.Encoder, global::Dropbox.Api.Files.ExportResult.Decoder, global::Dropbox.Api.Files.ExportError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<ExportArg, ExportResult, ExportError>(exportArg, "content", "/files/export", "user", global::Dropbox.Api.Files.ExportArg.Encoder, global::Dropbox.Api.Files.ExportResult.Decoder, global::Dropbox.Api.Files.ExportError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2170,15 +2232,17 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.ExportInfo.ExportAs" /> populated.</para>
         /// </summary>
         /// <param name="path">The path of the file to be exported.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="ExportError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<ExportResult>> ExportAsync(string path)
+        public t.Task<enc.IDownloadResponse<ExportResult>> ExportAsync(string path,
+                                                                       tr.CancellationToken cancellationToken = default)
         {
             var exportArg = new ExportArg(path);
 
-            return this.ExportAsync(exportArg);
+            return this.ExportAsync(exportArg, cancellationToken);
         }
 
         /// <summary>
@@ -2223,14 +2287,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Return the lock metadata for the given list of paths.</para>
         /// </summary>
         /// <param name="lockFileBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> GetFileLockBatchAsync(LockFileBatchArg lockFileBatchArg)
+        public t.Task<LockFileBatchResult> GetFileLockBatchAsync(LockFileBatchArg lockFileBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LockFileBatchArg, LockFileBatchResult, LockFileError>(lockFileBatchArg, "api", "/files/get_file_lock_batch", "user", global::Dropbox.Api.Files.LockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LockFileBatchArg, LockFileBatchResult, LockFileError>(lockFileBatchArg, "api", "/files/get_file_lock_batch", "user", global::Dropbox.Api.Files.LockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2255,16 +2320,18 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="entries">List of 'entries'. Each 'entry' contains a path of the file
         /// which will be locked or queried. Duplicate path arguments in the batch are
         /// considered only once.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> GetFileLockBatchAsync(col.IEnumerable<LockFileArg> entries)
+        public t.Task<LockFileBatchResult> GetFileLockBatchAsync(col.IEnumerable<LockFileArg> entries,
+                                                                 tr.CancellationToken cancellationToken = default)
         {
             var lockFileBatchArg = new LockFileBatchArg(entries);
 
-            return this.GetFileLockBatchAsync(lockFileBatchArg);
+            return this.GetFileLockBatchAsync(lockFileBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -2313,14 +2380,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Note: Metadata for the root folder is unsupported.</para>
         /// </summary>
         /// <param name="getMetadataArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetMetadataError"/>.</exception>
-        public t.Task<Metadata> GetMetadataAsync(GetMetadataArg getMetadataArg)
+        public t.Task<Metadata> GetMetadataAsync(GetMetadataArg getMetadataArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetMetadataArg, Metadata, GetMetadataError>(getMetadataArg, "api", "/files/get_metadata", "user", global::Dropbox.Api.Files.GetMetadataArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.GetMetadataError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetMetadataArg, Metadata, GetMetadataError>(getMetadataArg, "api", "/files/get_metadata", "user", global::Dropbox.Api.Files.GetMetadataArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.GetMetadataError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2356,6 +2424,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="includePropertyGroups">If set to a valid list of template IDs, <see
         /// cref="Dropbox.Api.Files.FileMetadata.PropertyGroups" /> is set if there exists
         /// property data associated with the file and each of the listed templates.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2365,7 +2434,8 @@ namespace Dropbox.Api.Files.Routes
                                                  bool includeMediaInfo = false,
                                                  bool includeDeleted = false,
                                                  bool includeHasExplicitSharedMembers = false,
-                                                 global::Dropbox.Api.FileProperties.TemplateFilterBase includePropertyGroups = null)
+                                                 global::Dropbox.Api.FileProperties.TemplateFilterBase includePropertyGroups = null,
+                                                 tr.CancellationToken cancellationToken = default)
         {
             var getMetadataArg = new GetMetadataArg(path,
                                                     includeMediaInfo,
@@ -2373,7 +2443,7 @@ namespace Dropbox.Api.Files.Routes
                                                     includeHasExplicitSharedMembers,
                                                     includePropertyGroups);
 
-            return this.GetMetadataAsync(getMetadataArg);
+            return this.GetMetadataAsync(getMetadataArg, cancellationToken);
         }
 
         /// <summary>
@@ -2445,13 +2515,14 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Other formats will return an unsupported extension error.</para>
         /// </summary>
         /// <param name="previewArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="PreviewError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<FileMetadata>> GetPreviewAsync(PreviewArg previewArg)
+        public t.Task<enc.IDownloadResponse<FileMetadata>> GetPreviewAsync(PreviewArg previewArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<PreviewArg, FileMetadata, PreviewError>(previewArg, "content", "/files/get_preview", "user", global::Dropbox.Api.Files.PreviewArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.PreviewError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<PreviewArg, FileMetadata, PreviewError>(previewArg, "content", "/files/get_preview", "user", global::Dropbox.Api.Files.PreviewArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.PreviewError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2482,17 +2553,19 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">The path of the file to preview.</param>
         /// <param name="rev">Please specify revision in <paramref name="path" />
         /// instead.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="PreviewError"/>.</exception>
         public t.Task<enc.IDownloadResponse<FileMetadata>> GetPreviewAsync(string path,
-                                                                           string rev = null)
+                                                                           string rev = null,
+                                                                           tr.CancellationToken cancellationToken = default)
         {
             var previewArg = new PreviewArg(path,
                                             rev);
 
-            return this.GetPreviewAsync(previewArg);
+            return this.GetPreviewAsync(previewArg, cancellationToken);
         }
 
         /// <summary>
@@ -2544,14 +2617,15 @@ namespace Dropbox.Api.Files.Routes
         /// automatically by the file's mime type.</para>
         /// </summary>
         /// <param name="getTemporaryLinkArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetTemporaryLinkError"/>.</exception>
-        public t.Task<GetTemporaryLinkResult> GetTemporaryLinkAsync(GetTemporaryLinkArg getTemporaryLinkArg)
+        public t.Task<GetTemporaryLinkResult> GetTemporaryLinkAsync(GetTemporaryLinkArg getTemporaryLinkArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTemporaryLinkArg, GetTemporaryLinkResult, GetTemporaryLinkError>(getTemporaryLinkArg, "api", "/files/get_temporary_link", "user", global::Dropbox.Api.Files.GetTemporaryLinkArg.Encoder, global::Dropbox.Api.Files.GetTemporaryLinkResult.Decoder, global::Dropbox.Api.Files.GetTemporaryLinkError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetTemporaryLinkArg, GetTemporaryLinkResult, GetTemporaryLinkError>(getTemporaryLinkArg, "api", "/files/get_temporary_link", "user", global::Dropbox.Api.Files.GetTemporaryLinkArg.Encoder, global::Dropbox.Api.Files.GetTemporaryLinkResult.Decoder, global::Dropbox.Api.Files.GetTemporaryLinkError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2577,16 +2651,18 @@ namespace Dropbox.Api.Files.Routes
         /// automatically by the file's mime type.</para>
         /// </summary>
         /// <param name="path">The path to the file you want a temporary link to.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetTemporaryLinkError"/>.</exception>
-        public t.Task<GetTemporaryLinkResult> GetTemporaryLinkAsync(string path)
+        public t.Task<GetTemporaryLinkResult> GetTemporaryLinkAsync(string path,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var getTemporaryLinkArg = new GetTemporaryLinkArg(path);
 
-            return this.GetTemporaryLinkAsync(getTemporaryLinkArg);
+            return this.GetTemporaryLinkAsync(getTemporaryLinkArg, cancellationToken);
         }
 
         /// <summary>
@@ -2674,11 +2750,12 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Temporary upload link has been recently consumed.</para>
         /// </summary>
         /// <param name="getTemporaryUploadLinkArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<GetTemporaryUploadLinkResult> GetTemporaryUploadLinkAsync(GetTemporaryUploadLinkArg getTemporaryUploadLinkArg)
+        public t.Task<GetTemporaryUploadLinkResult> GetTemporaryUploadLinkAsync(GetTemporaryUploadLinkArg getTemporaryUploadLinkArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTemporaryUploadLinkArg, GetTemporaryUploadLinkResult, enc.Empty>(getTemporaryUploadLinkArg, "api", "/files/get_temporary_upload_link", "user", global::Dropbox.Api.Files.GetTemporaryUploadLinkArg.Encoder, global::Dropbox.Api.Files.GetTemporaryUploadLinkResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<GetTemporaryUploadLinkArg, GetTemporaryUploadLinkResult, enc.Empty>(getTemporaryUploadLinkArg, "api", "/files/get_temporary_upload_link", "user", global::Dropbox.Api.Files.GetTemporaryUploadLinkArg.Encoder, global::Dropbox.Api.Files.GetTemporaryUploadLinkResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -2748,15 +2825,17 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="duration">How long before this link expires, in seconds.  Attempting
         /// to start an upload with this link longer than this period  of time after link
         /// creation will result in an error.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<GetTemporaryUploadLinkResult> GetTemporaryUploadLinkAsync(CommitInfo commitInfo,
-                                                                                double duration = 14400.0)
+                                                                                double duration = 14400.0,
+                                                                                tr.CancellationToken cancellationToken = default)
         {
             var getTemporaryUploadLinkArg = new GetTemporaryUploadLinkArg(commitInfo,
                                                                           duration);
 
-            return this.GetTemporaryUploadLinkAsync(getTemporaryUploadLinkArg);
+            return this.GetTemporaryUploadLinkAsync(getTemporaryUploadLinkArg, cancellationToken);
         }
 
         /// <summary>
@@ -2809,14 +2888,15 @@ namespace Dropbox.Api.Files.Routes
         /// be converted to a thumbnail.</para>
         /// </summary>
         /// <param name="thumbnailArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ThumbnailError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<FileMetadata>> GetThumbnailAsync(ThumbnailArg thumbnailArg)
+        public t.Task<enc.IDownloadResponse<FileMetadata>> GetThumbnailAsync(ThumbnailArg thumbnailArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<ThumbnailArg, FileMetadata, ThumbnailError>(thumbnailArg, "content", "/files/get_thumbnail", "user", global::Dropbox.Api.Files.ThumbnailArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.ThumbnailError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<ThumbnailArg, FileMetadata, ThumbnailError>(thumbnailArg, "content", "/files/get_thumbnail", "user", global::Dropbox.Api.Files.ThumbnailArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.ThumbnailError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2848,6 +2928,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="size">The size for the thumbnail image.</param>
         /// <param name="mode">How to resize and crop the image to achieve the desired
         /// size.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2856,14 +2937,15 @@ namespace Dropbox.Api.Files.Routes
         public t.Task<enc.IDownloadResponse<FileMetadata>> GetThumbnailAsync(string path,
                                                                              ThumbnailFormat format = null,
                                                                              ThumbnailSize size = null,
-                                                                             ThumbnailMode mode = null)
+                                                                             ThumbnailMode mode = null,
+                                                                             tr.CancellationToken cancellationToken = default)
         {
             var thumbnailArg = new ThumbnailArg(path,
                                                 format,
                                                 size,
                                                 mode);
 
-            return this.GetThumbnailAsync(thumbnailArg);
+            return this.GetThumbnailAsync(thumbnailArg, cancellationToken);
         }
 
         /// <summary>
@@ -2921,14 +3003,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Get a thumbnail for a file.</para>
         /// </summary>
         /// <param name="thumbnailV2Arg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ThumbnailV2Error"/>.</exception>
-        public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(ThumbnailV2Arg thumbnailV2Arg)
+        public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(ThumbnailV2Arg thumbnailV2Arg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<ThumbnailV2Arg, PreviewResult, ThumbnailV2Error>(thumbnailV2Arg, "content", "/files/get_thumbnail_v2", "user", global::Dropbox.Api.Files.ThumbnailV2Arg.Encoder, global::Dropbox.Api.Files.PreviewResult.Decoder, global::Dropbox.Api.Files.ThumbnailV2Error.Decoder);
+            return this.Transport.SendDownloadRequestAsync<ThumbnailV2Arg, PreviewResult, ThumbnailV2Error>(thumbnailV2Arg, "content", "/files/get_thumbnail_v2", "user", global::Dropbox.Api.Files.ThumbnailV2Arg.Encoder, global::Dropbox.Api.Files.PreviewResult.Decoder, global::Dropbox.Api.Files.ThumbnailV2Error.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2959,6 +3042,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="size">The size for the thumbnail image.</param>
         /// <param name="mode">How to resize and crop the image to achieve the desired
         /// size.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2967,14 +3051,15 @@ namespace Dropbox.Api.Files.Routes
         public t.Task<enc.IDownloadResponse<PreviewResult>> GetThumbnailV2Async(PathOrLink resource,
                                                                                 ThumbnailFormat format = null,
                                                                                 ThumbnailSize size = null,
-                                                                                ThumbnailMode mode = null)
+                                                                                ThumbnailMode mode = null,
+                                                                                tr.CancellationToken cancellationToken = default)
         {
             var thumbnailV2Arg = new ThumbnailV2Arg(resource,
                                                     format,
                                                     size,
                                                     mode);
 
-            return this.GetThumbnailV2Async(thumbnailV2Arg);
+            return this.GetThumbnailV2Async(thumbnailV2Arg, cancellationToken);
         }
 
         /// <summary>
@@ -3038,14 +3123,15 @@ namespace Dropbox.Api.Files.Routes
         /// be converted to a thumbnail.</para>
         /// </summary>
         /// <param name="getThumbnailBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetThumbnailBatchError"/>.</exception>
-        public t.Task<GetThumbnailBatchResult> GetThumbnailBatchAsync(GetThumbnailBatchArg getThumbnailBatchArg)
+        public t.Task<GetThumbnailBatchResult> GetThumbnailBatchAsync(GetThumbnailBatchArg getThumbnailBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetThumbnailBatchArg, GetThumbnailBatchResult, GetThumbnailBatchError>(getThumbnailBatchArg, "content", "/files/get_thumbnail_batch", "user", global::Dropbox.Api.Files.GetThumbnailBatchArg.Encoder, global::Dropbox.Api.Files.GetThumbnailBatchResult.Decoder, global::Dropbox.Api.Files.GetThumbnailBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetThumbnailBatchArg, GetThumbnailBatchResult, GetThumbnailBatchError>(getThumbnailBatchArg, "content", "/files/get_thumbnail_batch", "user", global::Dropbox.Api.Files.GetThumbnailBatchArg.Encoder, global::Dropbox.Api.Files.GetThumbnailBatchResult.Decoder, global::Dropbox.Api.Files.GetThumbnailBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3072,16 +3158,18 @@ namespace Dropbox.Api.Files.Routes
         /// be converted to a thumbnail.</para>
         /// </summary>
         /// <param name="entries">List of files to get thumbnails.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetThumbnailBatchError"/>.</exception>
-        public t.Task<GetThumbnailBatchResult> GetThumbnailBatchAsync(col.IEnumerable<ThumbnailArg> entries)
+        public t.Task<GetThumbnailBatchResult> GetThumbnailBatchAsync(col.IEnumerable<ThumbnailArg> entries,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var getThumbnailBatchArg = new GetThumbnailBatchArg(entries);
 
-            return this.GetThumbnailBatchAsync(getThumbnailBatchArg);
+            return this.GetThumbnailBatchAsync(getThumbnailBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -3154,14 +3242,15 @@ namespace Dropbox.Api.Files.Routes
         /// finishes.</para>
         /// </summary>
         /// <param name="listFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderError"/>.</exception>
-        public t.Task<ListFolderResult> ListFolderAsync(ListFolderArg listFolderArg)
+        public t.Task<ListFolderResult> ListFolderAsync(ListFolderArg listFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderArg, ListFolderResult, ListFolderError>(listFolderArg, "api", "/files/list_folder", "user", global::Dropbox.Api.Files.ListFolderArg.Encoder, global::Dropbox.Api.Files.ListFolderResult.Decoder, global::Dropbox.Api.Files.ListFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderArg, ListFolderResult, ListFolderError>(listFolderArg, "api", "/files/list_folder", "user", global::Dropbox.Api.Files.ListFolderArg.Encoder, global::Dropbox.Api.Files.ListFolderResult.Decoder, global::Dropbox.Api.Files.ListFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3236,6 +3325,7 @@ namespace Dropbox.Api.Files.Routes
         /// property data associated with the file and each of the listed templates.</param>
         /// <param name="includeNonDownloadableFiles">If true, include files that are not
         /// downloadable, i.e. Google Docs.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3250,7 +3340,8 @@ namespace Dropbox.Api.Files.Routes
                                                         uint? limit = null,
                                                         SharedLink sharedLink = null,
                                                         global::Dropbox.Api.FileProperties.TemplateFilterBase includePropertyGroups = null,
-                                                        bool includeNonDownloadableFiles = true)
+                                                        bool includeNonDownloadableFiles = true,
+                                                        tr.CancellationToken cancellationToken = default)
         {
             var listFolderArg = new ListFolderArg(path,
                                                   recursive,
@@ -3263,7 +3354,7 @@ namespace Dropbox.Api.Files.Routes
                                                   includePropertyGroups,
                                                   includeNonDownloadableFiles);
 
-            return this.ListFolderAsync(listFolderArg);
+            return this.ListFolderAsync(listFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -3356,14 +3447,15 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.ListFolderAsync" />.</para>
         /// </summary>
         /// <param name="listFolderContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderContinueError"/>.</exception>
-        public t.Task<ListFolderResult> ListFolderContinueAsync(ListFolderContinueArg listFolderContinueArg)
+        public t.Task<ListFolderResult> ListFolderContinueAsync(ListFolderContinueArg listFolderContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderContinueArg, ListFolderResult, ListFolderContinueError>(listFolderContinueArg, "api", "/files/list_folder/continue", "user", global::Dropbox.Api.Files.ListFolderContinueArg.Encoder, global::Dropbox.Api.Files.ListFolderResult.Decoder, global::Dropbox.Api.Files.ListFolderContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderContinueArg, ListFolderResult, ListFolderContinueError>(listFolderContinueArg, "api", "/files/list_folder/continue", "user", global::Dropbox.Api.Files.ListFolderContinueArg.Encoder, global::Dropbox.Api.Files.ListFolderResult.Decoder, global::Dropbox.Api.Files.ListFolderContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3392,16 +3484,18 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="cursor">The cursor returned by your last call to <see
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.ListFolderAsync" /> or <see
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.ListFolderContinueAsync" />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderContinueError"/>.</exception>
-        public t.Task<ListFolderResult> ListFolderContinueAsync(string cursor)
+        public t.Task<ListFolderResult> ListFolderContinueAsync(string cursor,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var listFolderContinueArg = new ListFolderContinueArg(cursor);
 
-            return this.ListFolderContinueAsync(listFolderContinueArg);
+            return this.ListFolderContinueAsync(listFolderContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -3454,14 +3548,15 @@ namespace Dropbox.Api.Files.Routes
         /// in Dropbox.</para>
         /// </summary>
         /// <param name="listFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderError"/>.</exception>
-        public t.Task<ListFolderGetLatestCursorResult> ListFolderGetLatestCursorAsync(ListFolderArg listFolderArg)
+        public t.Task<ListFolderGetLatestCursorResult> ListFolderGetLatestCursorAsync(ListFolderArg listFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderArg, ListFolderGetLatestCursorResult, ListFolderError>(listFolderArg, "api", "/files/list_folder/get_latest_cursor", "user", global::Dropbox.Api.Files.ListFolderArg.Encoder, global::Dropbox.Api.Files.ListFolderGetLatestCursorResult.Decoder, global::Dropbox.Api.Files.ListFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderArg, ListFolderGetLatestCursorResult, ListFolderError>(listFolderArg, "api", "/files/list_folder/get_latest_cursor", "user", global::Dropbox.Api.Files.ListFolderArg.Encoder, global::Dropbox.Api.Files.ListFolderGetLatestCursorResult.Decoder, global::Dropbox.Api.Files.ListFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3515,6 +3610,7 @@ namespace Dropbox.Api.Files.Routes
         /// property data associated with the file and each of the listed templates.</param>
         /// <param name="includeNonDownloadableFiles">If true, include files that are not
         /// downloadable, i.e. Google Docs.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3529,7 +3625,8 @@ namespace Dropbox.Api.Files.Routes
                                                                                       uint? limit = null,
                                                                                       SharedLink sharedLink = null,
                                                                                       global::Dropbox.Api.FileProperties.TemplateFilterBase includePropertyGroups = null,
-                                                                                      bool includeNonDownloadableFiles = true)
+                                                                                      bool includeNonDownloadableFiles = true,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var listFolderArg = new ListFolderArg(path,
                                                   recursive,
@@ -3542,7 +3639,7 @@ namespace Dropbox.Api.Files.Routes
                                                   includePropertyGroups,
                                                   includeNonDownloadableFiles);
 
-            return this.ListFolderGetLatestCursorAsync(listFolderArg);
+            return this.ListFolderGetLatestCursorAsync(listFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -3639,14 +3736,15 @@ namespace Dropbox.Api.Files.Routes
         /// documentation</a>.</para>
         /// </summary>
         /// <param name="listFolderLongpollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderLongpollError"/>.</exception>
-        public t.Task<ListFolderLongpollResult> ListFolderLongpollAsync(ListFolderLongpollArg listFolderLongpollArg)
+        public t.Task<ListFolderLongpollResult> ListFolderLongpollAsync(ListFolderLongpollArg listFolderLongpollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderLongpollArg, ListFolderLongpollResult, ListFolderLongpollError>(listFolderLongpollArg, "notify", "/files/list_folder/longpoll", "noauth", global::Dropbox.Api.Files.ListFolderLongpollArg.Encoder, global::Dropbox.Api.Files.ListFolderLongpollResult.Decoder, global::Dropbox.Api.Files.ListFolderLongpollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderLongpollArg, ListFolderLongpollResult, ListFolderLongpollError>(listFolderLongpollArg, "notify", "/files/list_folder/longpoll", "noauth", global::Dropbox.Api.Files.ListFolderLongpollArg.Encoder, global::Dropbox.Api.Files.ListFolderLongpollResult.Decoder, global::Dropbox.Api.Files.ListFolderLongpollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3684,18 +3782,20 @@ namespace Dropbox.Api.Files.Routes
         /// length of time, plus up to 90 seconds of random jitter added to avoid the
         /// thundering herd problem. Care should be taken when using this parameter, as some
         /// network infrastructure does not support long timeouts.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderLongpollError"/>.</exception>
         public t.Task<ListFolderLongpollResult> ListFolderLongpollAsync(string cursor,
-                                                                        ulong timeout = 30)
+                                                                        ulong timeout = 30,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var listFolderLongpollArg = new ListFolderLongpollArg(cursor,
                                                                   timeout);
 
-            return this.ListFolderLongpollAsync(listFolderLongpollArg);
+            return this.ListFolderLongpollAsync(listFolderLongpollArg, cancellationToken);
         }
 
         /// <summary>
@@ -3760,14 +3860,15 @@ namespace Dropbox.Api.Files.Routes
         /// revisions for a given file across moves or renames.</para>
         /// </summary>
         /// <param name="listRevisionsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListRevisionsError"/>.</exception>
-        public t.Task<ListRevisionsResult> ListRevisionsAsync(ListRevisionsArg listRevisionsArg)
+        public t.Task<ListRevisionsResult> ListRevisionsAsync(ListRevisionsArg listRevisionsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListRevisionsArg, ListRevisionsResult, ListRevisionsError>(listRevisionsArg, "api", "/files/list_revisions", "user", global::Dropbox.Api.Files.ListRevisionsArg.Encoder, global::Dropbox.Api.Files.ListRevisionsResult.Decoder, global::Dropbox.Api.Files.ListRevisionsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListRevisionsArg, ListRevisionsResult, ListRevisionsError>(listRevisionsArg, "api", "/files/list_revisions", "user", global::Dropbox.Api.Files.ListRevisionsArg.Encoder, global::Dropbox.Api.Files.ListRevisionsResult.Decoder, global::Dropbox.Api.Files.ListRevisionsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3802,6 +3903,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="mode">Determines the behavior of the API in listing the revisions for
         /// a given file path or id.</param>
         /// <param name="limit">The maximum number of revision entries returned.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3809,13 +3911,14 @@ namespace Dropbox.Api.Files.Routes
         /// cref="ListRevisionsError"/>.</exception>
         public t.Task<ListRevisionsResult> ListRevisionsAsync(string path,
                                                               ListRevisionsMode mode = null,
-                                                              ulong limit = 10)
+                                                              ulong limit = 10,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var listRevisionsArg = new ListRevisionsArg(path,
                                                         mode,
                                                         limit);
 
-            return this.ListRevisionsAsync(listRevisionsArg);
+            return this.ListRevisionsAsync(listRevisionsArg, cancellationToken);
         }
 
         /// <summary>
@@ -3870,14 +3973,15 @@ namespace Dropbox.Api.Files.Routes
         /// a list of the locked file paths and their metadata after this operation.</para>
         /// </summary>
         /// <param name="lockFileBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> LockFileBatchAsync(LockFileBatchArg lockFileBatchArg)
+        public t.Task<LockFileBatchResult> LockFileBatchAsync(LockFileBatchArg lockFileBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LockFileBatchArg, LockFileBatchResult, LockFileError>(lockFileBatchArg, "api", "/files/lock_file_batch", "user", global::Dropbox.Api.Files.LockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LockFileBatchArg, LockFileBatchResult, LockFileError>(lockFileBatchArg, "api", "/files/lock_file_batch", "user", global::Dropbox.Api.Files.LockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3904,16 +4008,18 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="entries">List of 'entries'. Each 'entry' contains a path of the file
         /// which will be locked or queried. Duplicate path arguments in the batch are
         /// considered only once.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> LockFileBatchAsync(col.IEnumerable<LockFileArg> entries)
+        public t.Task<LockFileBatchResult> LockFileBatchAsync(col.IEnumerable<LockFileArg> entries,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var lockFileBatchArg = new LockFileBatchArg(entries);
 
-            return this.LockFileBatchAsync(lockFileBatchArg);
+            return this.LockFileBatchAsync(lockFileBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -3963,14 +4069,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Note that we do not currently support case-only renaming.</para>
         /// </summary>
         /// <param name="relocationArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelocationError"/>.</exception>
-        public t.Task<RelocationResult> MoveV2Async(RelocationArg relocationArg)
+        public t.Task<RelocationResult> MoveV2Async(RelocationArg relocationArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationArg, RelocationResult, RelocationError>(relocationArg, "api", "/files/move_v2", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.RelocationResult.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelocationArg, RelocationResult, RelocationError>(relocationArg, "api", "/files/move_v2", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.RelocationResult.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4002,6 +4109,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4011,7 +4119,8 @@ namespace Dropbox.Api.Files.Routes
                                                     string toPath,
                                                     bool allowSharedFolder = false,
                                                     bool autorename = false,
-                                                    bool allowOwnershipTransfer = false)
+                                                    bool allowOwnershipTransfer = false,
+                                                    tr.CancellationToken cancellationToken = default)
         {
             var relocationArg = new RelocationArg(fromPath,
                                                   toPath,
@@ -4019,7 +4128,7 @@ namespace Dropbox.Api.Files.Routes
                                                   autorename,
                                                   allowOwnershipTransfer);
 
-            return this.MoveV2Async(relocationArg);
+            return this.MoveV2Async(relocationArg, cancellationToken);
         }
 
         /// <summary>
@@ -4080,15 +4189,16 @@ namespace Dropbox.Api.Files.Routes
         /// <para>If the source path is a folder all its contents will be moved.</para>
         /// </summary>
         /// <param name="relocationArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelocationError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use MoveV2Async instead.")]
-        public t.Task<Metadata> MoveAsync(RelocationArg relocationArg)
+        public t.Task<Metadata> MoveAsync(RelocationArg relocationArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationArg, Metadata, RelocationError>(relocationArg, "api", "/files/move", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelocationArg, Metadata, RelocationError>(relocationArg, "api", "/files/move", "user", global::Dropbox.Api.Files.RelocationArg.Encoder, global::Dropbox.Api.Files.Metadata.Decoder, global::Dropbox.Api.Files.RelocationError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4120,6 +4230,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4130,7 +4241,8 @@ namespace Dropbox.Api.Files.Routes
                                           string toPath,
                                           bool allowSharedFolder = false,
                                           bool autorename = false,
-                                          bool allowOwnershipTransfer = false)
+                                          bool allowOwnershipTransfer = false,
+                                          tr.CancellationToken cancellationToken = default)
         {
             var relocationArg = new RelocationArg(fromPath,
                                                   toPath,
@@ -4138,7 +4250,7 @@ namespace Dropbox.Api.Files.Routes
                                                   autorename,
                                                   allowOwnershipTransfer);
 
-            return this.MoveAsync(relocationArg);
+            return this.MoveAsync(relocationArg, cancellationToken);
         }
 
         /// <summary>
@@ -4210,11 +4322,12 @@ namespace Dropbox.Api.Files.Routes
         /// the job status.</para>
         /// </summary>
         /// <param name="moveBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<RelocationBatchV2Launch> MoveBatchV2Async(MoveBatchArg moveBatchArg)
+        public t.Task<RelocationBatchV2Launch> MoveBatchV2Async(MoveBatchArg moveBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MoveBatchArg, RelocationBatchV2Launch, enc.Empty>(moveBatchArg, "api", "/files/move_batch_v2", "user", global::Dropbox.Api.Files.MoveBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2Launch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<MoveBatchArg, RelocationBatchV2Launch, enc.Empty>(moveBatchArg, "api", "/files/move_batch_v2", "user", global::Dropbox.Api.Files.MoveBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2Launch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -4253,17 +4366,19 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<RelocationBatchV2Launch> MoveBatchV2Async(col.IEnumerable<RelocationPath> entries,
                                                                 bool autorename = false,
-                                                                bool allowOwnershipTransfer = false)
+                                                                bool allowOwnershipTransfer = false,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var moveBatchArg = new MoveBatchArg(entries,
                                                 autorename,
                                                 allowOwnershipTransfer);
 
-            return this.MoveBatchV2Async(moveBatchArg);
+            return this.MoveBatchV2Async(moveBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -4321,12 +4436,13 @@ namespace Dropbox.Api.Files.Routes
         /// job status.</para>
         /// </summary>
         /// <param name="relocationBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated, please use MoveBatchV2Async instead.")]
-        public t.Task<RelocationBatchLaunch> MoveBatchAsync(RelocationBatchArg relocationBatchArg)
+        public t.Task<RelocationBatchLaunch> MoveBatchAsync(RelocationBatchArg relocationBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelocationBatchArg, RelocationBatchLaunch, enc.Empty>(relocationBatchArg, "api", "/files/move_batch", "user", global::Dropbox.Api.Files.RelocationBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<RelocationBatchArg, RelocationBatchLaunch, enc.Empty>(relocationBatchArg, "api", "/files/move_batch", "user", global::Dropbox.Api.Files.RelocationBatchArg.Encoder, global::Dropbox.Api.Files.RelocationBatchLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -4362,20 +4478,22 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="allowOwnershipTransfer">Allow moves by owner even if it would result
         /// in an ownership transfer for the content being moved. This does not apply to
         /// copies.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated, please use MoveBatchV2Async instead.")]
         public t.Task<RelocationBatchLaunch> MoveBatchAsync(col.IEnumerable<RelocationPath> entries,
                                                             bool autorename = false,
                                                             bool allowSharedFolder = false,
-                                                            bool allowOwnershipTransfer = false)
+                                                            bool allowOwnershipTransfer = false,
+                                                            tr.CancellationToken cancellationToken = default)
         {
             var relocationBatchArg = new RelocationBatchArg(entries,
                                                             autorename,
                                                             allowSharedFolder,
                                                             allowOwnershipTransfer);
 
-            return this.MoveBatchAsync(relocationBatchArg);
+            return this.MoveBatchAsync(relocationBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -4435,14 +4553,15 @@ namespace Dropbox.Api.Files.Routes
         /// list of results for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RelocationBatchV2JobStatus> MoveBatchCheckV2Async(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<RelocationBatchV2JobStatus> MoveBatchCheckV2Async(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchV2JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/move_batch/check_v2", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchV2JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/move_batch/check_v2", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchV2JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4468,16 +4587,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RelocationBatchV2JobStatus> MoveBatchCheckV2Async(string asyncJobId)
+        public t.Task<RelocationBatchV2JobStatus> MoveBatchCheckV2Async(string asyncJobId,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.MoveBatchCheckV2Async(pollArg);
+            return this.MoveBatchCheckV2Async(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -4526,15 +4647,16 @@ namespace Dropbox.Api.Files.Routes
         /// returns list of results for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use MoveBatchCheckV2Async instead.")]
-        public t.Task<RelocationBatchJobStatus> MoveBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<RelocationBatchJobStatus> MoveBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/move_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RelocationBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/move_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.RelocationBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4561,17 +4683,19 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use MoveBatchCheckV2Async instead.")]
-        public t.Task<RelocationBatchJobStatus> MoveBatchCheckAsync(string asyncJobId)
+        public t.Task<RelocationBatchJobStatus> MoveBatchCheckAsync(string asyncJobId,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.MoveBatchCheckAsync(pollArg);
+            return this.MoveBatchCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -4625,12 +4749,13 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Note: This endpoint is only available for Dropbox Business apps.</para>
         /// </summary>
         /// <param name="deleteArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
-        public t.Task PermanentlyDeleteAsync(DeleteArg deleteArg)
+        public t.Task PermanentlyDeleteAsync(DeleteArg deleteArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteArg, enc.Empty, DeleteError>(deleteArg, "api", "/files/permanently_delete", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.DeleteError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DeleteArg, enc.Empty, DeleteError>(deleteArg, "api", "/files/permanently_delete", "user", global::Dropbox.Api.Files.DeleteArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.DeleteError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4660,16 +4785,18 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">Path in the user's Dropbox to delete.</param>
         /// <param name="parentRev">Perform delete if given "rev" matches the existing file's
         /// latest "rev". This field does not support deleting a folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="DeleteError"/>.</exception>
         public t.Task PermanentlyDeleteAsync(string path,
-                                             string parentRev = null)
+                                             string parentRev = null,
+                                             tr.CancellationToken cancellationToken = default)
         {
             var deleteArg = new DeleteArg(path,
                                           parentRev);
 
-            return this.PermanentlyDeleteAsync(deleteArg);
+            return this.PermanentlyDeleteAsync(deleteArg, cancellationToken);
         }
 
         /// <summary>
@@ -4715,14 +4842,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>The properties add route</para>
         /// </summary>
         /// <param name="addPropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.AddPropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task PropertiesAddAsync(global::Dropbox.Api.FileProperties.AddPropertiesArg addPropertiesArg)
+        public t.Task PropertiesAddAsync(global::Dropbox.Api.FileProperties.AddPropertiesArg addPropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.AddPropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.AddPropertiesError>(addPropertiesArg, "api", "/files/properties/add", "user", global::Dropbox.Api.FileProperties.AddPropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.AddPropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.AddPropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.AddPropertiesError>(addPropertiesArg, "api", "/files/properties/add", "user", global::Dropbox.Api.FileProperties.AddPropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.AddPropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4748,18 +4876,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="propertyGroups">The property groups which are to be added to a Dropbox
         /// file. No two groups in the input should  refer to the same template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.AddPropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task PropertiesAddAsync(string path,
-                                         col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups)
+                                         col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups,
+                                         tr.CancellationToken cancellationToken = default)
         {
             var addPropertiesArg = new global::Dropbox.Api.FileProperties.AddPropertiesArg(path,
                                                                                            propertyGroups);
 
-            return this.PropertiesAddAsync(addPropertiesArg);
+            return this.PropertiesAddAsync(addPropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -4808,14 +4938,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>The properties overwrite route</para>
         /// </summary>
         /// <param name="overwritePropertyGroupArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.InvalidPropertyGroupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task PropertiesOverwriteAsync(global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg overwritePropertyGroupArg)
+        public t.Task PropertiesOverwriteAsync(global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg overwritePropertyGroupArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg, enc.Empty, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError>(overwritePropertyGroupArg, "api", "/files/properties/overwrite", "user", global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg, enc.Empty, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError>(overwritePropertyGroupArg, "api", "/files/properties/overwrite", "user", global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.InvalidPropertyGroupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4841,18 +4972,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="propertyGroups">The property groups "snapshot" updates to force apply.
         /// No two groups in the input should  refer to the same template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.InvalidPropertyGroupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task PropertiesOverwriteAsync(string path,
-                                               col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups)
+                                               col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups,
+                                               tr.CancellationToken cancellationToken = default)
         {
             var overwritePropertyGroupArg = new global::Dropbox.Api.FileProperties.OverwritePropertyGroupArg(path,
                                                                                                              propertyGroups);
 
-            return this.PropertiesOverwriteAsync(overwritePropertyGroupArg);
+            return this.PropertiesOverwriteAsync(overwritePropertyGroupArg, cancellationToken);
         }
 
         /// <summary>
@@ -4901,14 +5034,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>The properties remove route</para>
         /// </summary>
         /// <param name="removePropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.RemovePropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task PropertiesRemoveAsync(global::Dropbox.Api.FileProperties.RemovePropertiesArg removePropertiesArg)
+        public t.Task PropertiesRemoveAsync(global::Dropbox.Api.FileProperties.RemovePropertiesArg removePropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.RemovePropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.RemovePropertiesError>(removePropertiesArg, "api", "/files/properties/remove", "user", global::Dropbox.Api.FileProperties.RemovePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.RemovePropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.RemovePropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.RemovePropertiesError>(removePropertiesArg, "api", "/files/properties/remove", "user", global::Dropbox.Api.FileProperties.RemovePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.RemovePropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4938,18 +5072,20 @@ namespace Dropbox.Api.Files.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.RemovePropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task PropertiesRemoveAsync(string path,
-                                            col.IEnumerable<string> propertyTemplateIds)
+                                            col.IEnumerable<string> propertyTemplateIds,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var removePropertiesArg = new global::Dropbox.Api.FileProperties.RemovePropertiesArg(path,
                                                                                                  propertyTemplateIds);
 
-            return this.PropertiesRemoveAsync(removePropertiesArg);
+            return this.PropertiesRemoveAsync(removePropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -5002,15 +5138,16 @@ namespace Dropbox.Api.Files.Routes
         /// <para>The properties template get route</para>
         /// </summary>
         /// <param name="getTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(global::Dropbox.Api.FileProperties.GetTemplateArg getTemplateArg)
+        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(global::Dropbox.Api.FileProperties.GetTemplateArg getTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.GetTemplateArg, global::Dropbox.Api.FileProperties.GetTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(getTemplateArg, "api", "/files/properties/template/get", "user", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.GetTemplateArg, global::Dropbox.Api.FileProperties.GetTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(getTemplateArg, "api", "/files/properties/template/get", "user", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5038,17 +5175,19 @@ namespace Dropbox.Api.Files.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(string templateId)
+        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(string templateId,
+                                                                                                       tr.CancellationToken cancellationToken = default)
         {
             var getTemplateArg = new global::Dropbox.Api.FileProperties.GetTemplateArg(templateId);
 
-            return this.PropertiesTemplateGetAsync(getTemplateArg);
+            return this.PropertiesTemplateGetAsync(getTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -5099,15 +5238,16 @@ namespace Dropbox.Api.Files.Routes
         /// <summary>
         /// <para>The properties template list route</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.ListTemplateResult> PropertiesTemplateListAsync()
+        public t.Task<global::Dropbox.Api.FileProperties.ListTemplateResult> PropertiesTemplateListAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, global::Dropbox.Api.FileProperties.ListTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(enc.Empty.Instance, "api", "/files/properties/template/list", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, global::Dropbox.Api.FileProperties.ListTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(enc.Empty.Instance, "api", "/files/properties/template/list", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5152,14 +5292,15 @@ namespace Dropbox.Api.Files.Routes
         /// <para>The properties update route</para>
         /// </summary>
         /// <param name="updatePropertiesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.UpdatePropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task PropertiesUpdateAsync(global::Dropbox.Api.FileProperties.UpdatePropertiesArg updatePropertiesArg)
+        public t.Task PropertiesUpdateAsync(global::Dropbox.Api.FileProperties.UpdatePropertiesArg updatePropertiesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.UpdatePropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.UpdatePropertiesError>(updatePropertiesArg, "api", "/files/properties/update", "user", global::Dropbox.Api.FileProperties.UpdatePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.UpdatePropertiesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.UpdatePropertiesArg, enc.Empty, global::Dropbox.Api.FileProperties.UpdatePropertiesError>(updatePropertiesArg, "api", "/files/properties/update", "user", global::Dropbox.Api.FileProperties.UpdatePropertiesArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.FileProperties.UpdatePropertiesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5185,18 +5326,20 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="path">A unique identifier for the file or folder.</param>
         /// <param name="updatePropertyGroups">The property groups "delta" updates to
         /// apply.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.UpdatePropertiesError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task PropertiesUpdateAsync(string path,
-                                            col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroupUpdate> updatePropertyGroups)
+                                            col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroupUpdate> updatePropertyGroups,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var updatePropertiesArg = new global::Dropbox.Api.FileProperties.UpdatePropertiesArg(path,
                                                                                                  updatePropertyGroups);
 
-            return this.PropertiesUpdateAsync(updatePropertiesArg);
+            return this.PropertiesUpdateAsync(updatePropertiesArg, cancellationToken);
         }
 
         /// <summary>
@@ -5245,13 +5388,14 @@ namespace Dropbox.Api.Files.Routes
         /// <para>Restore a specific revision of a file to the given path.</para>
         /// </summary>
         /// <param name="restoreArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="RestoreError"/>.</exception>
-        public t.Task<FileMetadata> RestoreAsync(RestoreArg restoreArg)
+        public t.Task<FileMetadata> RestoreAsync(RestoreArg restoreArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RestoreArg, FileMetadata, RestoreError>(restoreArg, "api", "/files/restore", "user", global::Dropbox.Api.Files.RestoreArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.RestoreError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RestoreArg, FileMetadata, RestoreError>(restoreArg, "api", "/files/restore", "user", global::Dropbox.Api.Files.RestoreArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.RestoreError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5275,17 +5419,19 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="path">The path to save the restored file.</param>
         /// <param name="rev">The revision to restore.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="RestoreError"/>.</exception>
         public t.Task<FileMetadata> RestoreAsync(string path,
-                                                 string rev)
+                                                 string rev,
+                                                 tr.CancellationToken cancellationToken = default)
         {
             var restoreArg = new RestoreArg(path,
                                             rev);
 
-            return this.RestoreAsync(restoreArg);
+            return this.RestoreAsync(restoreArg, cancellationToken);
         }
 
         /// <summary>
@@ -5337,13 +5483,14 @@ namespace Dropbox.Api.Files.Routes
         /// conflict (e.g. myfile (1).txt).</para>
         /// </summary>
         /// <param name="saveUrlArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SaveUrlError"/>.</exception>
-        public t.Task<SaveUrlResult> SaveUrlAsync(SaveUrlArg saveUrlArg)
+        public t.Task<SaveUrlResult> SaveUrlAsync(SaveUrlArg saveUrlArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SaveUrlArg, SaveUrlResult, SaveUrlError>(saveUrlArg, "api", "/files/save_url", "user", global::Dropbox.Api.Files.SaveUrlArg.Encoder, global::Dropbox.Api.Files.SaveUrlResult.Decoder, global::Dropbox.Api.Files.SaveUrlError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SaveUrlArg, SaveUrlResult, SaveUrlError>(saveUrlArg, "api", "/files/save_url", "user", global::Dropbox.Api.Files.SaveUrlArg.Encoder, global::Dropbox.Api.Files.SaveUrlResult.Decoder, global::Dropbox.Api.Files.SaveUrlError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5371,17 +5518,19 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="path">The path in Dropbox where the URL will be saved to.</param>
         /// <param name="url">The URL to be saved.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SaveUrlError"/>.</exception>
         public t.Task<SaveUrlResult> SaveUrlAsync(string path,
-                                                  string url)
+                                                  string url,
+                                                  tr.CancellationToken cancellationToken = default)
         {
             var saveUrlArg = new SaveUrlArg(path,
                                             url);
 
-            return this.SaveUrlAsync(saveUrlArg);
+            return this.SaveUrlAsync(saveUrlArg, cancellationToken);
         }
 
         /// <summary>
@@ -5430,14 +5579,15 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.SaveUrlAsync" /> job.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<SaveUrlJobStatus> SaveUrlCheckJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<SaveUrlJobStatus> SaveUrlCheckJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, SaveUrlJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/save_url/check_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.SaveUrlJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, SaveUrlJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/save_url/check_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.SaveUrlJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5462,16 +5612,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<SaveUrlJobStatus> SaveUrlCheckJobStatusAsync(string asyncJobId)
+        public t.Task<SaveUrlJobStatus> SaveUrlCheckJobStatusAsync(string asyncJobId,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.SaveUrlCheckJobStatusAsync(pollArg);
+            return this.SaveUrlCheckJobStatusAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -5521,14 +5673,15 @@ namespace Dropbox.Api.Files.Routes
         /// days.</para>
         /// </summary>
         /// <param name="searchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SearchError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use SearchV2Async instead.")]
-        public t.Task<SearchResult> SearchAsync(SearchArg searchArg)
+        public t.Task<SearchResult> SearchAsync(SearchArg searchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SearchArg, SearchResult, SearchError>(searchArg, "api", "/files/search", "user", global::Dropbox.Api.Files.SearchArg.Encoder, global::Dropbox.Api.Files.SearchResult.Decoder, global::Dropbox.Api.Files.SearchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SearchArg, SearchResult, SearchError>(searchArg, "api", "/files/search", "user", global::Dropbox.Api.Files.SearchArg.Encoder, global::Dropbox.Api.Files.SearchResult.Decoder, global::Dropbox.Api.Files.SearchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5566,6 +5719,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="mode">The search mode (filename, filename_and_content, or
         /// deleted_filename). Note that searching file content is only available for Dropbox
         /// Business accounts.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -5575,7 +5729,8 @@ namespace Dropbox.Api.Files.Routes
                                                 string query,
                                                 ulong start = 0,
                                                 ulong maxResults = 100,
-                                                SearchMode mode = null)
+                                                SearchMode mode = null,
+                                                tr.CancellationToken cancellationToken = default)
         {
             var searchArg = new SearchArg(path,
                                           query,
@@ -5583,7 +5738,7 @@ namespace Dropbox.Api.Files.Routes
                                           maxResults,
                                           mode);
 
-            return this.SearchAsync(searchArg);
+            return this.SearchAsync(searchArg, cancellationToken);
         }
 
         /// <summary>
@@ -5656,13 +5811,14 @@ namespace Dropbox.Api.Files.Routes
         /// results may not be returned.</para>
         /// </summary>
         /// <param name="searchV2Arg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SearchError"/>.</exception>
-        public t.Task<SearchV2Result> SearchV2Async(SearchV2Arg searchV2Arg)
+        public t.Task<SearchV2Result> SearchV2Async(SearchV2Arg searchV2Arg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SearchV2Arg, SearchV2Result, SearchError>(searchV2Arg, "api", "/files/search_v2", "user", global::Dropbox.Api.Files.SearchV2Arg.Encoder, global::Dropbox.Api.Files.SearchV2Result.Decoder, global::Dropbox.Api.Files.SearchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SearchV2Arg, SearchV2Result, SearchError>(searchV2Arg, "api", "/files/search_v2", "user", global::Dropbox.Api.Files.SearchV2Arg.Encoder, global::Dropbox.Api.Files.SearchV2Result.Decoder, global::Dropbox.Api.Files.SearchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5698,6 +5854,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="matchFieldOptions">Options for search results match fields.</param>
         /// <param name="includeHighlights">Deprecated and moved this option to
         /// SearchMatchFieldOptions.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -5705,14 +5862,15 @@ namespace Dropbox.Api.Files.Routes
         public t.Task<SearchV2Result> SearchV2Async(string query,
                                                     SearchOptions options = null,
                                                     SearchMatchFieldOptions matchFieldOptions = null,
-                                                    bool? includeHighlights = null)
+                                                    bool? includeHighlights = null,
+                                                    tr.CancellationToken cancellationToken = default)
         {
             var searchV2Arg = new SearchV2Arg(query,
                                               options,
                                               matchFieldOptions,
                                               includeHighlights);
 
-            return this.SearchV2Async(searchV2Arg);
+            return this.SearchV2Async(searchV2Arg, cancellationToken);
         }
 
         /// <summary>
@@ -5777,13 +5935,14 @@ namespace Dropbox.Api.Files.Routes
         /// results may not be returned.</para>
         /// </summary>
         /// <param name="searchV2ContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SearchError"/>.</exception>
-        public t.Task<SearchV2Result> SearchContinueV2Async(SearchV2ContinueArg searchV2ContinueArg)
+        public t.Task<SearchV2Result> SearchContinueV2Async(SearchV2ContinueArg searchV2ContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SearchV2ContinueArg, SearchV2Result, SearchError>(searchV2ContinueArg, "api", "/files/search/continue_v2", "user", global::Dropbox.Api.Files.SearchV2ContinueArg.Encoder, global::Dropbox.Api.Files.SearchV2Result.Decoder, global::Dropbox.Api.Files.SearchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SearchV2ContinueArg, SearchV2Result, SearchError>(searchV2ContinueArg, "api", "/files/search/continue_v2", "user", global::Dropbox.Api.Files.SearchV2ContinueArg.Encoder, global::Dropbox.Api.Files.SearchV2Result.Decoder, global::Dropbox.Api.Files.SearchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5816,15 +5975,17 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="cursor">The cursor returned by your last call to <see
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.SearchV2Async" />. Used to fetch the
         /// next page of results.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="SearchError"/>.</exception>
-        public t.Task<SearchV2Result> SearchContinueV2Async(string cursor)
+        public t.Task<SearchV2Result> SearchContinueV2Async(string cursor,
+                                                            tr.CancellationToken cancellationToken = default)
         {
             var searchV2ContinueArg = new SearchV2ContinueArg(cursor);
 
-            return this.SearchContinueV2Async(searchV2ContinueArg);
+            return this.SearchContinueV2Async(searchV2ContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -5874,14 +6035,15 @@ namespace Dropbox.Api.Files.Routes
         /// paths and their metadata after this operation.</para>
         /// </summary>
         /// <param name="unlockFileBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> UnlockFileBatchAsync(UnlockFileBatchArg unlockFileBatchArg)
+        public t.Task<LockFileBatchResult> UnlockFileBatchAsync(UnlockFileBatchArg unlockFileBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UnlockFileBatchArg, LockFileBatchResult, LockFileError>(unlockFileBatchArg, "api", "/files/unlock_file_batch", "user", global::Dropbox.Api.Files.UnlockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UnlockFileBatchArg, LockFileBatchResult, LockFileError>(unlockFileBatchArg, "api", "/files/unlock_file_batch", "user", global::Dropbox.Api.Files.UnlockFileBatchArg.Encoder, global::Dropbox.Api.Files.LockFileBatchResult.Decoder, global::Dropbox.Api.Files.LockFileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5909,16 +6071,18 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="entries">List of 'entries'. Each 'entry' contains a path of the file
         /// which will be unlocked. Duplicate path arguments in the batch are considered only
         /// once.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LockFileError"/>.</exception>
-        public t.Task<LockFileBatchResult> UnlockFileBatchAsync(col.IEnumerable<UnlockFileArg> entries)
+        public t.Task<LockFileBatchResult> UnlockFileBatchAsync(col.IEnumerable<UnlockFileArg> entries,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var unlockFileBatchArg = new UnlockFileBatchArg(entries);
 
-            return this.UnlockFileBatchAsync(unlockFileBatchArg);
+            return this.UnlockFileBatchAsync(unlockFileBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -5975,13 +6139,14 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="commitInfo">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see cref="UploadError"/>.</exception>
-        public t.Task<FileMetadata> UploadAsync(CommitInfo commitInfo, io.Stream body)
+        public t.Task<FileMetadata> UploadAsync(CommitInfo commitInfo, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<CommitInfo, FileMetadata, UploadError>(commitInfo, body, "content", "/files/upload", "user", global::Dropbox.Api.Files.CommitInfo.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadError.Decoder);
+            return this.Transport.SendUploadRequestAsync<CommitInfo, FileMetadata, UploadError>(commitInfo, body, "content", "/files/upload", "user", global::Dropbox.Api.Files.CommitInfo.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6034,6 +6199,7 @@ namespace Dropbox.Api.Files.Routes
         /// deleted. This also forces a conflict even when the target path refers to a file
         /// with identical contents.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6045,7 +6211,8 @@ namespace Dropbox.Api.Files.Routes
                                                 bool mute = false,
                                                 col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyGroup> propertyGroups = null,
                                                 bool strictConflict = false,
-                                                io.Stream body = null)
+                                                io.Stream body = null,
+                                                tr.CancellationToken cancellationToken = default)
         {
             var commitInfo = new CommitInfo(path,
                                             mode,
@@ -6055,7 +6222,7 @@ namespace Dropbox.Api.Files.Routes
                                             propertyGroups,
                                             strictConflict);
 
-            return this.UploadAsync(commitInfo, body);
+            return this.UploadAsync(commitInfo, body, cancellationToken);
         }
 
         /// <summary>
@@ -6143,13 +6310,14 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="uploadSessionAppendArg">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadSessionLookupError"/>.</exception>
-        public t.Task UploadSessionAppendV2Async(UploadSessionAppendArg uploadSessionAppendArg, io.Stream body)
+        public t.Task UploadSessionAppendV2Async(UploadSessionAppendArg uploadSessionAppendArg, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<UploadSessionAppendArg, enc.Empty, UploadSessionLookupError>(uploadSessionAppendArg, body, "content", "/files/upload_session/append_v2", "user", global::Dropbox.Api.Files.UploadSessionAppendArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.UploadSessionLookupError.Decoder);
+            return this.Transport.SendUploadRequestAsync<UploadSessionAppendArg, enc.Empty, UploadSessionLookupError>(uploadSessionAppendArg, body, "content", "/files/upload_session/append_v2", "user", global::Dropbox.Api.Files.UploadSessionAppendArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.UploadSessionLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6186,18 +6354,20 @@ namespace Dropbox.Api.Files.Routes
         /// cref="Dropbox.Api.Files.Routes.FilesUserRoutes.UploadSessionAppendV2Async" />
         /// anymore with the current session.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadSessionLookupError"/>.</exception>
         public t.Task UploadSessionAppendV2Async(UploadSessionCursor cursor,
                                                  bool close = false,
-                                                 io.Stream body = null)
+                                                 io.Stream body = null,
+                                                 tr.CancellationToken cancellationToken = default)
         {
             var uploadSessionAppendArg = new UploadSessionAppendArg(cursor,
                                                                     close);
 
-            return this.UploadSessionAppendV2Async(uploadSessionAppendArg, body);
+            return this.UploadSessionAppendV2Async(uploadSessionAppendArg, body, cancellationToken);
         }
 
         /// <summary>
@@ -6256,14 +6426,15 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="uploadSessionCursor">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadSessionLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use UploadSessionAppendV2Async instead.")]
-        public t.Task UploadSessionAppendAsync(UploadSessionCursor uploadSessionCursor, io.Stream body)
+        public t.Task UploadSessionAppendAsync(UploadSessionCursor uploadSessionCursor, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<UploadSessionCursor, enc.Empty, UploadSessionLookupError>(uploadSessionCursor, body, "content", "/files/upload_session/append", "user", global::Dropbox.Api.Files.UploadSessionCursor.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.UploadSessionLookupError.Decoder);
+            return this.Transport.SendUploadRequestAsync<UploadSessionCursor, enc.Empty, UploadSessionLookupError>(uploadSessionCursor, body, "content", "/files/upload_session/append", "user", global::Dropbox.Api.Files.UploadSessionCursor.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Files.UploadSessionLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6301,6 +6472,7 @@ namespace Dropbox.Api.Files.Routes
         /// to make sure upload data isn't lost or duplicated in the event of a network
         /// error.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
@@ -6308,12 +6480,13 @@ namespace Dropbox.Api.Files.Routes
         [sys.Obsolete("This function is deprecated, please use UploadSessionAppendV2Async instead.")]
         public t.Task UploadSessionAppendAsync(string sessionId,
                                                ulong offset,
-                                               io.Stream body)
+                                               io.Stream body,
+                                               tr.CancellationToken cancellationToken = default)
         {
             var uploadSessionCursor = new UploadSessionCursor(sessionId,
                                                               offset);
 
-            return this.UploadSessionAppendAsync(uploadSessionCursor, body);
+            return this.UploadSessionAppendAsync(uploadSessionCursor, body, cancellationToken);
         }
 
         /// <summary>
@@ -6376,14 +6549,15 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="uploadSessionFinishArg">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadSessionFinishError"/>.</exception>
-        public t.Task<FileMetadata> UploadSessionFinishAsync(UploadSessionFinishArg uploadSessionFinishArg, io.Stream body)
+        public t.Task<FileMetadata> UploadSessionFinishAsync(UploadSessionFinishArg uploadSessionFinishArg, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<UploadSessionFinishArg, FileMetadata, UploadSessionFinishError>(uploadSessionFinishArg, body, "content", "/files/upload_session/finish", "user", global::Dropbox.Api.Files.UploadSessionFinishArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadSessionFinishError.Decoder);
+            return this.Transport.SendUploadRequestAsync<UploadSessionFinishArg, FileMetadata, UploadSessionFinishError>(uploadSessionFinishArg, body, "content", "/files/upload_session/finish", "user", global::Dropbox.Api.Files.UploadSessionFinishArg.Encoder, global::Dropbox.Api.Files.FileMetadata.Decoder, global::Dropbox.Api.Files.UploadSessionFinishError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6418,6 +6592,7 @@ namespace Dropbox.Api.Files.Routes
         /// <param name="commit">Contains the path and other optional modifiers for the
         /// commit.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6425,12 +6600,13 @@ namespace Dropbox.Api.Files.Routes
         /// cref="UploadSessionFinishError"/>.</exception>
         public t.Task<FileMetadata> UploadSessionFinishAsync(UploadSessionCursor cursor,
                                                              CommitInfo commit,
-                                                             io.Stream body)
+                                                             io.Stream body,
+                                                             tr.CancellationToken cancellationToken = default)
         {
             var uploadSessionFinishArg = new UploadSessionFinishArg(cursor,
                                                                     commit);
 
-            return this.UploadSessionFinishAsync(uploadSessionFinishArg, body);
+            return this.UploadSessionFinishAsync(uploadSessionFinishArg, body, cancellationToken);
         }
 
         /// <summary>
@@ -6506,11 +6682,12 @@ namespace Dropbox.Api.Files.Routes
         /// transport limit page</a>.</para>
         /// </summary>
         /// <param name="uploadSessionFinishBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<UploadSessionFinishBatchLaunch> UploadSessionFinishBatchAsync(UploadSessionFinishBatchArg uploadSessionFinishBatchArg)
+        public t.Task<UploadSessionFinishBatchLaunch> UploadSessionFinishBatchAsync(UploadSessionFinishBatchArg uploadSessionFinishBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UploadSessionFinishBatchArg, UploadSessionFinishBatchLaunch, enc.Empty>(uploadSessionFinishBatchArg, "api", "/files/upload_session/finish_batch", "user", global::Dropbox.Api.Files.UploadSessionFinishBatchArg.Encoder, global::Dropbox.Api.Files.UploadSessionFinishBatchLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<UploadSessionFinishBatchArg, UploadSessionFinishBatchLaunch, enc.Empty>(uploadSessionFinishBatchArg, "api", "/files/upload_session/finish_batch", "user", global::Dropbox.Api.Files.UploadSessionFinishBatchArg.Encoder, global::Dropbox.Api.Files.UploadSessionFinishBatchLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -6557,13 +6734,15 @@ namespace Dropbox.Api.Files.Routes
         /// transport limit page</a>.</para>
         /// </summary>
         /// <param name="entries">Commit information for each file in the batch.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<UploadSessionFinishBatchLaunch> UploadSessionFinishBatchAsync(col.IEnumerable<UploadSessionFinishArg> entries)
+        public t.Task<UploadSessionFinishBatchLaunch> UploadSessionFinishBatchAsync(col.IEnumerable<UploadSessionFinishArg> entries,
+                                                                                    tr.CancellationToken cancellationToken = default)
         {
             var uploadSessionFinishBatchArg = new UploadSessionFinishBatchArg(entries);
 
-            return this.UploadSessionFinishBatchAsync(uploadSessionFinishBatchArg);
+            return this.UploadSessionFinishBatchAsync(uploadSessionFinishBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -6608,14 +6787,15 @@ namespace Dropbox.Api.Files.Routes
         /// If success, it returns list of result for each entry.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<UploadSessionFinishBatchJobStatus> UploadSessionFinishBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<UploadSessionFinishBatchJobStatus> UploadSessionFinishBatchCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, UploadSessionFinishBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/upload_session/finish_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.UploadSessionFinishBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, UploadSessionFinishBatchJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/files/upload_session/finish_batch/check", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Files.UploadSessionFinishBatchJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6642,16 +6822,18 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<UploadSessionFinishBatchJobStatus> UploadSessionFinishBatchCheckAsync(string asyncJobId)
+        public t.Task<UploadSessionFinishBatchJobStatus> UploadSessionFinishBatchCheckAsync(string asyncJobId,
+                                                                                            tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.UploadSessionFinishBatchCheckAsync(pollArg);
+            return this.UploadSessionFinishBatchCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -6745,14 +6927,15 @@ namespace Dropbox.Api.Files.Routes
         /// </summary>
         /// <param name="uploadSessionStartArg">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UploadSessionStartError"/>.</exception>
-        public t.Task<UploadSessionStartResult> UploadSessionStartAsync(UploadSessionStartArg uploadSessionStartArg, io.Stream body)
+        public t.Task<UploadSessionStartResult> UploadSessionStartAsync(UploadSessionStartArg uploadSessionStartArg, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<UploadSessionStartArg, UploadSessionStartResult, UploadSessionStartError>(uploadSessionStartArg, body, "content", "/files/upload_session/start", "user", global::Dropbox.Api.Files.UploadSessionStartArg.Encoder, global::Dropbox.Api.Files.UploadSessionStartResult.Decoder, global::Dropbox.Api.Files.UploadSessionStartError.Decoder);
+            return this.Transport.SendUploadRequestAsync<UploadSessionStartArg, UploadSessionStartResult, UploadSessionStartError>(uploadSessionStartArg, body, "content", "/files/upload_session/start", "user", global::Dropbox.Api.Files.UploadSessionStartArg.Encoder, global::Dropbox.Api.Files.UploadSessionStartResult.Decoder, global::Dropbox.Api.Files.UploadSessionStartError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6828,6 +7011,7 @@ namespace Dropbox.Api.Files.Routes
         /// specified, default is <see cref="Dropbox.Api.Files.UploadSessionType.Sequential"
         /// />.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6835,12 +7019,13 @@ namespace Dropbox.Api.Files.Routes
         /// cref="UploadSessionStartError"/>.</exception>
         public t.Task<UploadSessionStartResult> UploadSessionStartAsync(bool close = false,
                                                                         UploadSessionType sessionType = null,
-                                                                        io.Stream body = null)
+                                                                        io.Stream body = null,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var uploadSessionStartArg = new UploadSessionStartArg(close,
                                                                   sessionType);
 
-            return this.UploadSessionStartAsync(uploadSessionStartArg, body);
+            return this.UploadSessionStartAsync(uploadSessionStartArg, body, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Paper/PaperUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Paper/PaperUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Paper.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -43,14 +44,15 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for more information.</para>
         /// </summary>
         /// <param name="refPaperDoc">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsArchiveAsync(RefPaperDoc refPaperDoc)
+        public t.Task DocsArchiveAsync(RefPaperDoc refPaperDoc, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RefPaperDoc, enc.Empty, DocLookupError>(refPaperDoc, "api", "/paper/docs/archive", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RefPaperDoc, enc.Empty, DocLookupError>(refPaperDoc, "api", "/paper/docs/archive", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -83,16 +85,18 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for more information.</para>
         /// </summary>
         /// <param name="docId">The Paper doc ID.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsArchiveAsync(string docId)
+        public t.Task DocsArchiveAsync(string docId,
+                                       tr.CancellationToken cancellationToken = default)
         {
             var refPaperDoc = new RefPaperDoc(docId);
 
-            return this.DocsArchiveAsync(refPaperDoc);
+            return this.DocsArchiveAsync(refPaperDoc, cancellationToken);
         }
 
         /// <summary>
@@ -145,15 +149,16 @@ namespace Dropbox.Api.Paper.Routes
         /// </summary>
         /// <param name="paperDocCreateArgs">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PaperDocCreateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<PaperDocCreateUpdateResult> DocsCreateAsync(PaperDocCreateArgs paperDocCreateArgs, io.Stream body)
+        public t.Task<PaperDocCreateUpdateResult> DocsCreateAsync(PaperDocCreateArgs paperDocCreateArgs, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<PaperDocCreateArgs, PaperDocCreateUpdateResult, PaperDocCreateError>(paperDocCreateArgs, body, "api", "/paper/docs/create", "user", global::Dropbox.Api.Paper.PaperDocCreateArgs.Encoder, global::Dropbox.Api.Paper.PaperDocCreateUpdateResult.Decoder, global::Dropbox.Api.Paper.PaperDocCreateError.Decoder);
+            return this.Transport.SendUploadRequestAsync<PaperDocCreateArgs, PaperDocCreateUpdateResult, PaperDocCreateError>(paperDocCreateArgs, body, "api", "/paper/docs/create", "user", global::Dropbox.Api.Paper.PaperDocCreateArgs.Encoder, global::Dropbox.Api.Paper.PaperDocCreateUpdateResult.Decoder, global::Dropbox.Api.Paper.PaperDocCreateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -189,6 +194,7 @@ namespace Dropbox.Api.Paper.Routes
         /// created. The API user has to have write access to this folder or error is
         /// thrown.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -197,12 +203,13 @@ namespace Dropbox.Api.Paper.Routes
         [sys.Obsolete("This function is deprecated")]
         public t.Task<PaperDocCreateUpdateResult> DocsCreateAsync(ImportFormat importFormat,
                                                                   string parentFolderId = null,
-                                                                  io.Stream body = null)
+                                                                  io.Stream body = null,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var paperDocCreateArgs = new PaperDocCreateArgs(importFormat,
                                                             parentFolderId);
 
-            return this.DocsCreateAsync(paperDocCreateArgs, body);
+            return this.DocsCreateAsync(paperDocCreateArgs, body, cancellationToken);
         }
 
         /// <summary>
@@ -264,15 +271,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="paperDocExport">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<enc.IDownloadResponse<PaperDocExportResult>> DocsDownloadAsync(PaperDocExport paperDocExport)
+        public t.Task<enc.IDownloadResponse<PaperDocExportResult>> DocsDownloadAsync(PaperDocExport paperDocExport, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<PaperDocExport, PaperDocExportResult, DocLookupError>(paperDocExport, "api", "/paper/docs/download", "user", global::Dropbox.Api.Paper.PaperDocExport.Encoder, global::Dropbox.Api.Paper.PaperDocExportResult.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<PaperDocExport, PaperDocExportResult, DocLookupError>(paperDocExport, "api", "/paper/docs/download", "user", global::Dropbox.Api.Paper.PaperDocExport.Encoder, global::Dropbox.Api.Paper.PaperDocExportResult.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -304,6 +312,7 @@ namespace Dropbox.Api.Paper.Routes
         /// </summary>
         /// <param name="docId">The Paper doc ID.</param>
         /// <param name="exportFormat">The export format</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -311,12 +320,13 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<enc.IDownloadResponse<PaperDocExportResult>> DocsDownloadAsync(string docId,
-                                                                                     ExportFormat exportFormat)
+                                                                                     ExportFormat exportFormat,
+                                                                                     tr.CancellationToken cancellationToken = default)
         {
             var paperDocExport = new PaperDocExport(docId,
                                                     exportFormat);
 
-            return this.DocsDownloadAsync(paperDocExport);
+            return this.DocsDownloadAsync(paperDocExport, cancellationToken);
         }
 
         /// <summary>
@@ -377,15 +387,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listUsersOnFolderArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListAsync(ListUsersOnFolderArgs listUsersOnFolderArgs)
+        public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListAsync(ListUsersOnFolderArgs listUsersOnFolderArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListUsersOnFolderArgs, ListUsersOnFolderResponse, DocLookupError>(listUsersOnFolderArgs, "api", "/paper/docs/folder_users/list", "user", global::Dropbox.Api.Paper.ListUsersOnFolderArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnFolderResponse.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListUsersOnFolderArgs, ListUsersOnFolderResponse, DocLookupError>(listUsersOnFolderArgs, "api", "/paper/docs/folder_users/list", "user", global::Dropbox.Api.Paper.ListUsersOnFolderArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnFolderResponse.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -422,6 +433,7 @@ namespace Dropbox.Api.Paper.Routes
         /// <param name="limit">Size limit per batch. The maximum number of users that can be
         /// retrieved per batch is 1000. Higher value results in invalid arguments
         /// error.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -429,12 +441,13 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListAsync(string docId,
-                                                                          int limit = 1000)
+                                                                          int limit = 1000,
+                                                                          tr.CancellationToken cancellationToken = default)
         {
             var listUsersOnFolderArgs = new ListUsersOnFolderArgs(docId,
                                                                   limit);
 
-            return this.DocsFolderUsersListAsync(listUsersOnFolderArgs);
+            return this.DocsFolderUsersListAsync(listUsersOnFolderArgs, cancellationToken);
         }
 
         /// <summary>
@@ -496,15 +509,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listUsersOnFolderContinueArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListUsersCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListContinueAsync(ListUsersOnFolderContinueArgs listUsersOnFolderContinueArgs)
+        public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListContinueAsync(ListUsersOnFolderContinueArgs listUsersOnFolderContinueArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListUsersOnFolderContinueArgs, ListUsersOnFolderResponse, ListUsersCursorError>(listUsersOnFolderContinueArgs, "api", "/paper/docs/folder_users/list/continue", "user", global::Dropbox.Api.Paper.ListUsersOnFolderContinueArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnFolderResponse.Decoder, global::Dropbox.Api.Paper.ListUsersCursorError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListUsersOnFolderContinueArgs, ListUsersOnFolderResponse, ListUsersCursorError>(listUsersOnFolderContinueArgs, "api", "/paper/docs/folder_users/list/continue", "user", global::Dropbox.Api.Paper.ListUsersOnFolderContinueArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnFolderResponse.Decoder, global::Dropbox.Api.Paper.ListUsersCursorError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -542,6 +556,7 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsFolderUsersListAsync" /> or <see
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsFolderUsersListContinueAsync"
         /// />. Allows for pagination.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -549,12 +564,13 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="ListUsersCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<ListUsersOnFolderResponse> DocsFolderUsersListContinueAsync(string docId,
-                                                                                  string cursor)
+                                                                                  string cursor,
+                                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listUsersOnFolderContinueArgs = new ListUsersOnFolderContinueArgs(docId,
                                                                                   cursor);
 
-            return this.DocsFolderUsersListContinueAsync(listUsersOnFolderContinueArgs);
+            return this.DocsFolderUsersListContinueAsync(listUsersOnFolderContinueArgs, cancellationToken);
         }
 
         /// <summary>
@@ -623,15 +639,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="refPaperDoc">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<FoldersContainingPaperDoc> DocsGetFolderInfoAsync(RefPaperDoc refPaperDoc)
+        public t.Task<FoldersContainingPaperDoc> DocsGetFolderInfoAsync(RefPaperDoc refPaperDoc, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RefPaperDoc, FoldersContainingPaperDoc, DocLookupError>(refPaperDoc, "api", "/paper/docs/get_folder_info", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, global::Dropbox.Api.Paper.FoldersContainingPaperDoc.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RefPaperDoc, FoldersContainingPaperDoc, DocLookupError>(refPaperDoc, "api", "/paper/docs/get_folder_info", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, global::Dropbox.Api.Paper.FoldersContainingPaperDoc.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -669,17 +686,19 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="docId">The Paper doc ID.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<FoldersContainingPaperDoc> DocsGetFolderInfoAsync(string docId)
+        public t.Task<FoldersContainingPaperDoc> DocsGetFolderInfoAsync(string docId,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var refPaperDoc = new RefPaperDoc(docId);
 
-            return this.DocsGetFolderInfoAsync(refPaperDoc);
+            return this.DocsGetFolderInfoAsync(refPaperDoc, cancellationToken);
         }
 
         /// <summary>
@@ -736,12 +755,13 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listPaperDocsArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListPaperDocsResponse> DocsListAsync(ListPaperDocsArgs listPaperDocsArgs)
+        public t.Task<ListPaperDocsResponse> DocsListAsync(ListPaperDocsArgs listPaperDocsArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListPaperDocsArgs, ListPaperDocsResponse, enc.Empty>(listPaperDocsArgs, "api", "/paper/docs/list", "user", global::Dropbox.Api.Paper.ListPaperDocsArgs.Encoder, global::Dropbox.Api.Paper.ListPaperDocsResponse.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<ListPaperDocsArgs, ListPaperDocsResponse, enc.Empty>(listPaperDocsArgs, "api", "/paper/docs/list", "user", global::Dropbox.Api.Paper.ListPaperDocsArgs.Encoder, global::Dropbox.Api.Paper.ListPaperDocsResponse.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -782,20 +802,22 @@ namespace Dropbox.Api.Paper.Routes
         /// <param name="limit">Size limit per batch. The maximum number of docs that can be
         /// retrieved per batch is 1000. Higher value results in invalid arguments
         /// error.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<ListPaperDocsResponse> DocsListAsync(ListPaperDocsFilterBy filterBy = null,
                                                            ListPaperDocsSortBy sortBy = null,
                                                            ListPaperDocsSortOrder sortOrder = null,
-                                                           int limit = 1000)
+                                                           int limit = 1000,
+                                                           tr.CancellationToken cancellationToken = default)
         {
             var listPaperDocsArgs = new ListPaperDocsArgs(filterBy,
                                                           sortBy,
                                                           sortOrder,
                                                           limit);
 
-            return this.DocsListAsync(listPaperDocsArgs);
+            return this.DocsListAsync(listPaperDocsArgs, cancellationToken);
         }
 
         /// <summary>
@@ -863,15 +885,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listPaperDocsContinueArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListDocsCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListPaperDocsResponse> DocsListContinueAsync(ListPaperDocsContinueArgs listPaperDocsContinueArgs)
+        public t.Task<ListPaperDocsResponse> DocsListContinueAsync(ListPaperDocsContinueArgs listPaperDocsContinueArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListPaperDocsContinueArgs, ListPaperDocsResponse, ListDocsCursorError>(listPaperDocsContinueArgs, "api", "/paper/docs/list/continue", "user", global::Dropbox.Api.Paper.ListPaperDocsContinueArgs.Encoder, global::Dropbox.Api.Paper.ListPaperDocsResponse.Decoder, global::Dropbox.Api.Paper.ListDocsCursorError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListPaperDocsContinueArgs, ListPaperDocsResponse, ListDocsCursorError>(listPaperDocsContinueArgs, "api", "/paper/docs/list/continue", "user", global::Dropbox.Api.Paper.ListPaperDocsContinueArgs.Encoder, global::Dropbox.Api.Paper.ListPaperDocsResponse.Decoder, global::Dropbox.Api.Paper.ListDocsCursorError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -907,17 +930,19 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsListAsync" /> or <see
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsListContinueAsync" />. Allows
         /// for pagination.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListDocsCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListPaperDocsResponse> DocsListContinueAsync(string cursor)
+        public t.Task<ListPaperDocsResponse> DocsListContinueAsync(string cursor,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var listPaperDocsContinueArgs = new ListPaperDocsContinueArgs(cursor);
 
-            return this.DocsListContinueAsync(listPaperDocsContinueArgs);
+            return this.DocsListContinueAsync(listPaperDocsContinueArgs, cancellationToken);
         }
 
         /// <summary>
@@ -977,14 +1002,15 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="refPaperDoc">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsPermanentlyDeleteAsync(RefPaperDoc refPaperDoc)
+        public t.Task DocsPermanentlyDeleteAsync(RefPaperDoc refPaperDoc, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RefPaperDoc, enc.Empty, DocLookupError>(refPaperDoc, "api", "/paper/docs/permanently_delete", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RefPaperDoc, enc.Empty, DocLookupError>(refPaperDoc, "api", "/paper/docs/permanently_delete", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1017,16 +1043,18 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="docId">The Paper doc ID.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsPermanentlyDeleteAsync(string docId)
+        public t.Task DocsPermanentlyDeleteAsync(string docId,
+                                                 tr.CancellationToken cancellationToken = default)
         {
             var refPaperDoc = new RefPaperDoc(docId);
 
-            return this.DocsPermanentlyDeleteAsync(refPaperDoc);
+            return this.DocsPermanentlyDeleteAsync(refPaperDoc, cancellationToken);
         }
 
         /// <summary>
@@ -1078,15 +1106,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="refPaperDoc">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<SharingPolicy> DocsSharingPolicyGetAsync(RefPaperDoc refPaperDoc)
+        public t.Task<SharingPolicy> DocsSharingPolicyGetAsync(RefPaperDoc refPaperDoc, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RefPaperDoc, SharingPolicy, DocLookupError>(refPaperDoc, "api", "/paper/docs/sharing_policy/get", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, global::Dropbox.Api.Paper.SharingPolicy.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RefPaperDoc, SharingPolicy, DocLookupError>(refPaperDoc, "api", "/paper/docs/sharing_policy/get", "user", global::Dropbox.Api.Paper.RefPaperDoc.Encoder, global::Dropbox.Api.Paper.SharingPolicy.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1117,17 +1146,19 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="docId">The Paper doc ID.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<SharingPolicy> DocsSharingPolicyGetAsync(string docId)
+        public t.Task<SharingPolicy> DocsSharingPolicyGetAsync(string docId,
+                                                               tr.CancellationToken cancellationToken = default)
         {
             var refPaperDoc = new RefPaperDoc(docId);
 
-            return this.DocsSharingPolicyGetAsync(refPaperDoc);
+            return this.DocsSharingPolicyGetAsync(refPaperDoc, cancellationToken);
         }
 
         /// <summary>
@@ -1186,14 +1217,15 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="paperDocSharingPolicy">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsSharingPolicySetAsync(PaperDocSharingPolicy paperDocSharingPolicy)
+        public t.Task DocsSharingPolicySetAsync(PaperDocSharingPolicy paperDocSharingPolicy, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<PaperDocSharingPolicy, enc.Empty, DocLookupError>(paperDocSharingPolicy, "api", "/paper/docs/sharing_policy/set", "user", global::Dropbox.Api.Paper.PaperDocSharingPolicy.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<PaperDocSharingPolicy, enc.Empty, DocLookupError>(paperDocSharingPolicy, "api", "/paper/docs/sharing_policy/set", "user", global::Dropbox.Api.Paper.PaperDocSharingPolicy.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1230,18 +1262,20 @@ namespace Dropbox.Api.Paper.Routes
         /// <param name="docId">The Paper doc ID.</param>
         /// <param name="sharingPolicy">The default sharing policy to be set for the Paper
         /// doc.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task DocsSharingPolicySetAsync(string docId,
-                                                SharingPolicy sharingPolicy)
+                                                SharingPolicy sharingPolicy,
+                                                tr.CancellationToken cancellationToken = default)
         {
             var paperDocSharingPolicy = new PaperDocSharingPolicy(docId,
                                                                   sharingPolicy);
 
-            return this.DocsSharingPolicySetAsync(paperDocSharingPolicy);
+            return this.DocsSharingPolicySetAsync(paperDocSharingPolicy, cancellationToken);
         }
 
         /// <summary>
@@ -1298,15 +1332,16 @@ namespace Dropbox.Api.Paper.Routes
         /// </summary>
         /// <param name="paperDocUpdateArgs">The request parameters</param>
         /// <param name="body">The content to upload.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PaperDocUpdateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<PaperDocCreateUpdateResult> DocsUpdateAsync(PaperDocUpdateArgs paperDocUpdateArgs, io.Stream body)
+        public t.Task<PaperDocCreateUpdateResult> DocsUpdateAsync(PaperDocUpdateArgs paperDocUpdateArgs, io.Stream body, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendUploadRequestAsync<PaperDocUpdateArgs, PaperDocCreateUpdateResult, PaperDocUpdateError>(paperDocUpdateArgs, body, "api", "/paper/docs/update", "user", global::Dropbox.Api.Paper.PaperDocUpdateArgs.Encoder, global::Dropbox.Api.Paper.PaperDocCreateUpdateResult.Decoder, global::Dropbox.Api.Paper.PaperDocUpdateError.Decoder);
+            return this.Transport.SendUploadRequestAsync<PaperDocUpdateArgs, PaperDocCreateUpdateResult, PaperDocUpdateError>(paperDocUpdateArgs, body, "api", "/paper/docs/update", "user", global::Dropbox.Api.Paper.PaperDocUpdateArgs.Encoder, global::Dropbox.Api.Paper.PaperDocCreateUpdateResult.Decoder, global::Dropbox.Api.Paper.PaperDocUpdateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1344,6 +1379,7 @@ namespace Dropbox.Api.Paper.Routes
         /// writes.</param>
         /// <param name="importFormat">The format of provided data.</param>
         /// <param name="body">The document to upload</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1354,14 +1390,15 @@ namespace Dropbox.Api.Paper.Routes
                                                                   PaperDocUpdatePolicy docUpdatePolicy,
                                                                   long revision,
                                                                   ImportFormat importFormat,
-                                                                  io.Stream body)
+                                                                  io.Stream body,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var paperDocUpdateArgs = new PaperDocUpdateArgs(docId,
                                                             docUpdatePolicy,
                                                             revision,
                                                             importFormat);
 
-            return this.DocsUpdateAsync(paperDocUpdateArgs, body);
+            return this.DocsUpdateAsync(paperDocUpdateArgs, body, cancellationToken);
         }
 
         /// <summary>
@@ -1431,15 +1468,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="addPaperDocUser">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<col.List<AddPaperDocUserMemberResult>> DocsUsersAddAsync(AddPaperDocUser addPaperDocUser)
+        public t.Task<col.List<AddPaperDocUserMemberResult>> DocsUsersAddAsync(AddPaperDocUser addPaperDocUser, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddPaperDocUser, col.List<AddPaperDocUserMemberResult>, DocLookupError>(addPaperDocUser, "api", "/paper/docs/users/add", "user", global::Dropbox.Api.Paper.AddPaperDocUser.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Paper.AddPaperDocUserMemberResult.Decoder), global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddPaperDocUser, col.List<AddPaperDocUserMemberResult>, DocLookupError>(addPaperDocUser, "api", "/paper/docs/users/add", "user", global::Dropbox.Api.Paper.AddPaperDocUser.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Paper.AddPaperDocUserMemberResult.Decoder), global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1478,6 +1516,7 @@ namespace Dropbox.Api.Paper.Routes
         /// successfully added member.</param>
         /// <param name="quiet">Clients should set this to true if no email message shall be
         /// sent to added users.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1487,14 +1526,15 @@ namespace Dropbox.Api.Paper.Routes
         public t.Task<col.List<AddPaperDocUserMemberResult>> DocsUsersAddAsync(string docId,
                                                                                col.IEnumerable<AddMember> members,
                                                                                string customMessage = null,
-                                                                               bool quiet = false)
+                                                                               bool quiet = false,
+                                                                               tr.CancellationToken cancellationToken = default)
         {
             var addPaperDocUser = new AddPaperDocUser(docId,
                                                       members,
                                                       customMessage,
                                                       quiet);
 
-            return this.DocsUsersAddAsync(addPaperDocUser);
+            return this.DocsUsersAddAsync(addPaperDocUser, cancellationToken);
         }
 
         /// <summary>
@@ -1565,15 +1605,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listUsersOnPaperDocArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListUsersOnPaperDocResponse> DocsUsersListAsync(ListUsersOnPaperDocArgs listUsersOnPaperDocArgs)
+        public t.Task<ListUsersOnPaperDocResponse> DocsUsersListAsync(ListUsersOnPaperDocArgs listUsersOnPaperDocArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListUsersOnPaperDocArgs, ListUsersOnPaperDocResponse, DocLookupError>(listUsersOnPaperDocArgs, "api", "/paper/docs/users/list", "user", global::Dropbox.Api.Paper.ListUsersOnPaperDocArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnPaperDocResponse.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListUsersOnPaperDocArgs, ListUsersOnPaperDocResponse, DocLookupError>(listUsersOnPaperDocArgs, "api", "/paper/docs/users/list", "user", global::Dropbox.Api.Paper.ListUsersOnPaperDocArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnPaperDocResponse.Decoder, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1613,6 +1654,7 @@ namespace Dropbox.Api.Paper.Routes
         /// error.</param>
         /// <param name="filterBy">Specify this attribute if you want to obtain users that have
         /// already accessed the Paper doc.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1621,13 +1663,14 @@ namespace Dropbox.Api.Paper.Routes
         [sys.Obsolete("This function is deprecated")]
         public t.Task<ListUsersOnPaperDocResponse> DocsUsersListAsync(string docId,
                                                                       int limit = 1000,
-                                                                      UserOnPaperDocFilter filterBy = null)
+                                                                      UserOnPaperDocFilter filterBy = null,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var listUsersOnPaperDocArgs = new ListUsersOnPaperDocArgs(docId,
                                                                       limit,
                                                                       filterBy);
 
-            return this.DocsUsersListAsync(listUsersOnPaperDocArgs);
+            return this.DocsUsersListAsync(listUsersOnPaperDocArgs, cancellationToken);
         }
 
         /// <summary>
@@ -1693,15 +1736,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="listUsersOnPaperDocContinueArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListUsersCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<ListUsersOnPaperDocResponse> DocsUsersListContinueAsync(ListUsersOnPaperDocContinueArgs listUsersOnPaperDocContinueArgs)
+        public t.Task<ListUsersOnPaperDocResponse> DocsUsersListContinueAsync(ListUsersOnPaperDocContinueArgs listUsersOnPaperDocContinueArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListUsersOnPaperDocContinueArgs, ListUsersOnPaperDocResponse, ListUsersCursorError>(listUsersOnPaperDocContinueArgs, "api", "/paper/docs/users/list/continue", "user", global::Dropbox.Api.Paper.ListUsersOnPaperDocContinueArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnPaperDocResponse.Decoder, global::Dropbox.Api.Paper.ListUsersCursorError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListUsersOnPaperDocContinueArgs, ListUsersOnPaperDocResponse, ListUsersCursorError>(listUsersOnPaperDocContinueArgs, "api", "/paper/docs/users/list/continue", "user", global::Dropbox.Api.Paper.ListUsersOnPaperDocContinueArgs.Encoder, global::Dropbox.Api.Paper.ListUsersOnPaperDocResponse.Decoder, global::Dropbox.Api.Paper.ListUsersCursorError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1738,6 +1782,7 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsUsersListAsync" /> or <see
         /// cref="Dropbox.Api.Paper.Routes.PaperUserRoutes.DocsUsersListContinueAsync" />.
         /// Allows for pagination.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1745,12 +1790,13 @@ namespace Dropbox.Api.Paper.Routes
         /// cref="ListUsersCursorError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<ListUsersOnPaperDocResponse> DocsUsersListContinueAsync(string docId,
-                                                                              string cursor)
+                                                                              string cursor,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var listUsersOnPaperDocContinueArgs = new ListUsersOnPaperDocContinueArgs(docId,
                                                                                       cursor);
 
-            return this.DocsUsersListContinueAsync(listUsersOnPaperDocContinueArgs);
+            return this.DocsUsersListContinueAsync(listUsersOnPaperDocContinueArgs, cancellationToken);
         }
 
         /// <summary>
@@ -1813,14 +1859,15 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="removePaperDocUser">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task DocsUsersRemoveAsync(RemovePaperDocUser removePaperDocUser)
+        public t.Task DocsUsersRemoveAsync(RemovePaperDocUser removePaperDocUser, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemovePaperDocUser, enc.Empty, DocLookupError>(removePaperDocUser, "api", "/paper/docs/users/remove", "user", global::Dropbox.Api.Paper.RemovePaperDocUser.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemovePaperDocUser, enc.Empty, DocLookupError>(removePaperDocUser, "api", "/paper/docs/users/remove", "user", global::Dropbox.Api.Paper.RemovePaperDocUser.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Paper.DocLookupError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1855,18 +1902,20 @@ namespace Dropbox.Api.Paper.Routes
         /// <param name="docId">The Paper doc ID.</param>
         /// <param name="member">User which should be removed from the Paper doc. Specify only
         /// email address or Dropbox account ID.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DocLookupError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task DocsUsersRemoveAsync(string docId,
-                                           global::Dropbox.Api.Sharing.MemberSelector member)
+                                           global::Dropbox.Api.Sharing.MemberSelector member,
+                                           tr.CancellationToken cancellationToken = default)
         {
             var removePaperDocUser = new RemovePaperDocUser(docId,
                                                             member);
 
-            return this.DocsUsersRemoveAsync(removePaperDocUser);
+            return this.DocsUsersRemoveAsync(removePaperDocUser, cancellationToken);
         }
 
         /// <summary>
@@ -1922,15 +1971,16 @@ namespace Dropbox.Api.Paper.Routes
         /// Migration Guide</a> for migration information.</para>
         /// </summary>
         /// <param name="paperFolderCreateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="PaperFolderCreateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<PaperFolderCreateResult> FoldersCreateAsync(PaperFolderCreateArg paperFolderCreateArg)
+        public t.Task<PaperFolderCreateResult> FoldersCreateAsync(PaperFolderCreateArg paperFolderCreateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<PaperFolderCreateArg, PaperFolderCreateResult, PaperFolderCreateError>(paperFolderCreateArg, "api", "/paper/folders/create", "user", global::Dropbox.Api.Paper.PaperFolderCreateArg.Encoder, global::Dropbox.Api.Paper.PaperFolderCreateResult.Decoder, global::Dropbox.Api.Paper.PaperFolderCreateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<PaperFolderCreateArg, PaperFolderCreateResult, PaperFolderCreateError>(paperFolderCreateArg, "api", "/paper/folders/create", "user", global::Dropbox.Api.Paper.PaperFolderCreateArg.Encoder, global::Dropbox.Api.Paper.PaperFolderCreateResult.Decoder, global::Dropbox.Api.Paper.PaperFolderCreateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1970,6 +2020,7 @@ namespace Dropbox.Api.Paper.Routes
         /// folder will inherit the type (private or team folder) from its parent. We will by
         /// default create a top-level private folder if both parent_folder_id and
         /// is_team_folder are not supplied.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1978,13 +2029,14 @@ namespace Dropbox.Api.Paper.Routes
         [sys.Obsolete("This function is deprecated")]
         public t.Task<PaperFolderCreateResult> FoldersCreateAsync(string name,
                                                                   string parentFolderId = null,
-                                                                  bool? isTeamFolder = null)
+                                                                  bool? isTeamFolder = null,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var paperFolderCreateArg = new PaperFolderCreateArg(name,
                                                                 parentFolderId,
                                                                 isTeamFolder);
 
-            return this.FoldersCreateAsync(paperFolderCreateArg);
+            return this.FoldersCreateAsync(paperFolderCreateArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Sharing/SharingUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Sharing/SharingUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Sharing.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -34,14 +35,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Adds specified members to a file.</para>
         /// </summary>
         /// <param name="addFileMemberArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddFileMemberError"/>.</exception>
-        public t.Task<col.List<FileMemberActionResult>> AddFileMemberAsync(AddFileMemberArgs addFileMemberArgs)
+        public t.Task<col.List<FileMemberActionResult>> AddFileMemberAsync(AddFileMemberArgs addFileMemberArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddFileMemberArgs, col.List<FileMemberActionResult>, AddFileMemberError>(addFileMemberArgs, "api", "/sharing/add_file_member", "user", global::Dropbox.Api.Sharing.AddFileMemberArgs.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.FileMemberActionResult.Decoder), global::Dropbox.Api.Sharing.AddFileMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddFileMemberArgs, col.List<FileMemberActionResult>, AddFileMemberError>(addFileMemberArgs, "api", "/sharing/add_file_member", "user", global::Dropbox.Api.Sharing.AddFileMemberArgs.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.FileMemberActionResult.Decoder), global::Dropbox.Api.Sharing.AddFileMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -75,6 +77,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// want to give new members.</param>
         /// <param name="addMessageAsComment">If the custom message should be added as a
         /// comment on the file.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -85,7 +88,8 @@ namespace Dropbox.Api.Sharing.Routes
                                                                            string customMessage = null,
                                                                            bool quiet = false,
                                                                            AccessLevel accessLevel = null,
-                                                                           bool addMessageAsComment = false)
+                                                                           bool addMessageAsComment = false,
+                                                                           tr.CancellationToken cancellationToken = default)
         {
             var addFileMemberArgs = new AddFileMemberArgs(file,
                                                           members,
@@ -94,7 +98,7 @@ namespace Dropbox.Api.Sharing.Routes
                                                           accessLevel,
                                                           addMessageAsComment);
 
-            return this.AddFileMemberAsync(addFileMemberArgs);
+            return this.AddFileMemberAsync(addFileMemberArgs, cancellationToken);
         }
 
         /// <summary>
@@ -166,13 +170,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// behalf.</para>
         /// </summary>
         /// <param name="addFolderMemberArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddFolderMemberError"/>.</exception>
-        public t.Task AddFolderMemberAsync(AddFolderMemberArg addFolderMemberArg)
+        public t.Task AddFolderMemberAsync(AddFolderMemberArg addFolderMemberArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddFolderMemberArg, enc.Empty, AddFolderMemberError>(addFolderMemberArg, "api", "/sharing/add_folder_member", "user", global::Dropbox.Api.Sharing.AddFolderMemberArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.AddFolderMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddFolderMemberArg, enc.Empty, AddFolderMemberError>(addFolderMemberArg, "api", "/sharing/add_folder_member", "user", global::Dropbox.Api.Sharing.AddFolderMemberArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.AddFolderMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -206,6 +211,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// notifications of their invite.</param>
         /// <param name="customMessage">Optional message to display to added members in their
         /// invitation.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
@@ -213,14 +219,15 @@ namespace Dropbox.Api.Sharing.Routes
         public t.Task AddFolderMemberAsync(string sharedFolderId,
                                            col.IEnumerable<AddMember> members,
                                            bool quiet = false,
-                                           string customMessage = null)
+                                           string customMessage = null,
+                                           tr.CancellationToken cancellationToken = default)
         {
             var addFolderMemberArg = new AddFolderMemberArg(sharedFolderId,
                                                             members,
                                                             quiet,
                                                             customMessage);
 
-            return this.AddFolderMemberAsync(addFolderMemberArg);
+            return this.AddFolderMemberAsync(addFolderMemberArg, cancellationToken);
         }
 
         /// <summary>
@@ -275,15 +282,16 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Identical to update_file_member but with less information returned.</para>
         /// </summary>
         /// <param name="changeFileMemberAccessArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="FileMemberActionError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use UpdateFileMemberAsync instead.")]
-        public t.Task<FileMemberActionResult> ChangeFileMemberAccessAsync(ChangeFileMemberAccessArgs changeFileMemberAccessArgs)
+        public t.Task<FileMemberActionResult> ChangeFileMemberAccessAsync(ChangeFileMemberAccessArgs changeFileMemberAccessArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ChangeFileMemberAccessArgs, FileMemberActionResult, FileMemberActionError>(changeFileMemberAccessArgs, "api", "/sharing/change_file_member_access", "user", global::Dropbox.Api.Sharing.ChangeFileMemberAccessArgs.Encoder, global::Dropbox.Api.Sharing.FileMemberActionResult.Decoder, global::Dropbox.Api.Sharing.FileMemberActionError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ChangeFileMemberAccessArgs, FileMemberActionResult, FileMemberActionError>(changeFileMemberAccessArgs, "api", "/sharing/change_file_member_access", "user", global::Dropbox.Api.Sharing.ChangeFileMemberAccessArgs.Encoder, global::Dropbox.Api.Sharing.FileMemberActionResult.Decoder, global::Dropbox.Api.Sharing.FileMemberActionError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -309,6 +317,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="file">File for which we are changing a member's access.</param>
         /// <param name="member">The member whose access we are changing.</param>
         /// <param name="accessLevel">The new access level for the member.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -317,13 +326,14 @@ namespace Dropbox.Api.Sharing.Routes
         [sys.Obsolete("This function is deprecated, please use UpdateFileMemberAsync instead.")]
         public t.Task<FileMemberActionResult> ChangeFileMemberAccessAsync(string file,
                                                                           MemberSelector member,
-                                                                          AccessLevel accessLevel)
+                                                                          AccessLevel accessLevel,
+                                                                          tr.CancellationToken cancellationToken = default)
         {
             var changeFileMemberAccessArgs = new ChangeFileMemberAccessArgs(file,
                                                                             member,
                                                                             accessLevel);
 
-            return this.ChangeFileMemberAccessAsync(changeFileMemberAccessArgs);
+            return this.ChangeFileMemberAccessAsync(changeFileMemberAccessArgs, cancellationToken);
         }
 
         /// <summary>
@@ -377,14 +387,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns the status of an asynchronous job.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<JobStatus> CheckJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<JobStatus> CheckJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, JobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.JobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -408,16 +419,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<JobStatus> CheckJobStatusAsync(string asyncJobId)
+        public t.Task<JobStatus> CheckJobStatusAsync(string asyncJobId,
+                                                     tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CheckJobStatusAsync(pollArg);
+            return this.CheckJobStatusAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -464,14 +477,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns the status of an asynchronous job for sharing a folder.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RemoveMemberJobStatus> CheckRemoveMemberJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<RemoveMemberJobStatus> CheckRemoveMemberJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RemoveMemberJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_remove_member_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.RemoveMemberJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, RemoveMemberJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_remove_member_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.RemoveMemberJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -496,16 +510,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<RemoveMemberJobStatus> CheckRemoveMemberJobStatusAsync(string asyncJobId)
+        public t.Task<RemoveMemberJobStatus> CheckRemoveMemberJobStatusAsync(string asyncJobId,
+                                                                             tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CheckRemoveMemberJobStatusAsync(pollArg);
+            return this.CheckRemoveMemberJobStatusAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -553,14 +569,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns the status of an asynchronous job for sharing a folder.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<ShareFolderJobStatus> CheckShareJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<ShareFolderJobStatus> CheckShareJobStatusAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, ShareFolderJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_share_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, ShareFolderJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/sharing/check_share_job_status", "user", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -584,16 +601,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<ShareFolderJobStatus> CheckShareJobStatusAsync(string asyncJobId)
+        public t.Task<ShareFolderJobStatus> CheckShareJobStatusAsync(string asyncJobId,
+                                                                     tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.CheckShareJobStatusAsync(pollArg);
+            return this.CheckShareJobStatusAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -652,15 +671,16 @@ namespace Dropbox.Api.Sharing.Routes
         /// />.</para>
         /// </summary>
         /// <param name="createSharedLinkArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateSharedLinkError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use CreateSharedLinkWithSettingsAsync instead.")]
-        public t.Task<PathLinkMetadata> CreateSharedLinkAsync(CreateSharedLinkArg createSharedLinkArg)
+        public t.Task<PathLinkMetadata> CreateSharedLinkAsync(CreateSharedLinkArg createSharedLinkArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateSharedLinkArg, PathLinkMetadata, CreateSharedLinkError>(createSharedLinkArg, "api", "/sharing/create_shared_link", "user", global::Dropbox.Api.Sharing.CreateSharedLinkArg.Encoder, global::Dropbox.Api.Sharing.PathLinkMetadata.Decoder, global::Dropbox.Api.Sharing.CreateSharedLinkError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CreateSharedLinkArg, PathLinkMetadata, CreateSharedLinkError>(createSharedLinkArg, "api", "/sharing/create_shared_link", "user", global::Dropbox.Api.Sharing.CreateSharedLinkArg.Encoder, global::Dropbox.Api.Sharing.PathLinkMetadata.Decoder, global::Dropbox.Api.Sharing.CreateSharedLinkError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -701,6 +721,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// set this to either <see cref="Dropbox.Api.Sharing.PendingUploadMode.File" /> or
         /// <see cref="Dropbox.Api.Sharing.PendingUploadMode.Folder" /> to indicate whether to
         /// assume it's a file or folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -709,13 +730,14 @@ namespace Dropbox.Api.Sharing.Routes
         [sys.Obsolete("This function is deprecated, please use CreateSharedLinkWithSettingsAsync instead.")]
         public t.Task<PathLinkMetadata> CreateSharedLinkAsync(string path,
                                                               bool shortUrl = false,
-                                                              PendingUploadMode pendingUpload = null)
+                                                              PendingUploadMode pendingUpload = null,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var createSharedLinkArg = new CreateSharedLinkArg(path,
                                                               shortUrl,
                                                               pendingUpload);
 
-            return this.CreateSharedLinkAsync(createSharedLinkArg);
+            return this.CreateSharedLinkAsync(createSharedLinkArg, cancellationToken);
         }
 
         /// <summary>
@@ -775,14 +797,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// shared folder settings).</para>
         /// </summary>
         /// <param name="createSharedLinkWithSettingsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateSharedLinkWithSettingsError"/>.</exception>
-        public t.Task<SharedLinkMetadata> CreateSharedLinkWithSettingsAsync(CreateSharedLinkWithSettingsArg createSharedLinkWithSettingsArg)
+        public t.Task<SharedLinkMetadata> CreateSharedLinkWithSettingsAsync(CreateSharedLinkWithSettingsArg createSharedLinkWithSettingsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CreateSharedLinkWithSettingsArg, SharedLinkMetadata, CreateSharedLinkWithSettingsError>(createSharedLinkWithSettingsArg, "api", "/sharing/create_shared_link_with_settings", "user", global::Dropbox.Api.Sharing.CreateSharedLinkWithSettingsArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.CreateSharedLinkWithSettingsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CreateSharedLinkWithSettingsArg, SharedLinkMetadata, CreateSharedLinkWithSettingsError>(createSharedLinkWithSettingsArg, "api", "/sharing/create_shared_link_with_settings", "user", global::Dropbox.Api.Sharing.CreateSharedLinkWithSettingsArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.CreateSharedLinkWithSettingsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -811,18 +834,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="path">The path to be shared by the shared link.</param>
         /// <param name="settings">The requested settings for the newly created shared
         /// link.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CreateSharedLinkWithSettingsError"/>.</exception>
         public t.Task<SharedLinkMetadata> CreateSharedLinkWithSettingsAsync(string path,
-                                                                            SharedLinkSettings settings = null)
+                                                                            SharedLinkSettings settings = null,
+                                                                            tr.CancellationToken cancellationToken = default)
         {
             var createSharedLinkWithSettingsArg = new CreateSharedLinkWithSettingsArg(path,
                                                                                       settings);
 
-            return this.CreateSharedLinkWithSettingsAsync(createSharedLinkWithSettingsArg);
+            return this.CreateSharedLinkWithSettingsAsync(createSharedLinkWithSettingsArg, cancellationToken);
         }
 
         /// <summary>
@@ -873,14 +898,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns shared file metadata.</para>
         /// </summary>
         /// <param name="getFileMetadataArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetFileMetadataError"/>.</exception>
-        public t.Task<SharedFileMetadata> GetFileMetadataAsync(GetFileMetadataArg getFileMetadataArg)
+        public t.Task<SharedFileMetadata> GetFileMetadataAsync(GetFileMetadataArg getFileMetadataArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetFileMetadataArg, SharedFileMetadata, GetFileMetadataError>(getFileMetadataArg, "api", "/sharing/get_file_metadata", "user", global::Dropbox.Api.Sharing.GetFileMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMetadata.Decoder, global::Dropbox.Api.Sharing.GetFileMetadataError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetFileMetadataArg, SharedFileMetadata, GetFileMetadataError>(getFileMetadataArg, "api", "/sharing/get_file_metadata", "user", global::Dropbox.Api.Sharing.GetFileMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMetadata.Decoder, global::Dropbox.Api.Sharing.GetFileMetadataError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -907,18 +933,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFileMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the file.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetFileMetadataError"/>.</exception>
         public t.Task<SharedFileMetadata> GetFileMetadataAsync(string file,
-                                                               col.IEnumerable<FileAction> actions = null)
+                                                               col.IEnumerable<FileAction> actions = null,
+                                                               tr.CancellationToken cancellationToken = default)
         {
             var getFileMetadataArg = new GetFileMetadataArg(file,
                                                             actions);
 
-            return this.GetFileMetadataAsync(getFileMetadataArg);
+            return this.GetFileMetadataAsync(getFileMetadataArg, cancellationToken);
         }
 
         /// <summary>
@@ -970,14 +998,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns shared file metadata.</para>
         /// </summary>
         /// <param name="getFileMetadataBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
-        public t.Task<col.List<GetFileMetadataBatchResult>> GetFileMetadataBatchAsync(GetFileMetadataBatchArg getFileMetadataBatchArg)
+        public t.Task<col.List<GetFileMetadataBatchResult>> GetFileMetadataBatchAsync(GetFileMetadataBatchArg getFileMetadataBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetFileMetadataBatchArg, col.List<GetFileMetadataBatchResult>, SharingUserError>(getFileMetadataBatchArg, "api", "/sharing/get_file_metadata/batch", "user", global::Dropbox.Api.Sharing.GetFileMetadataBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.GetFileMetadataBatchResult.Decoder), global::Dropbox.Api.Sharing.SharingUserError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetFileMetadataBatchArg, col.List<GetFileMetadataBatchResult>, SharingUserError>(getFileMetadataBatchArg, "api", "/sharing/get_file_metadata/batch", "user", global::Dropbox.Api.Sharing.GetFileMetadataBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.GetFileMetadataBatchResult.Decoder), global::Dropbox.Api.Sharing.SharingUserError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1004,18 +1033,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFileMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the file.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
         public t.Task<col.List<GetFileMetadataBatchResult>> GetFileMetadataBatchAsync(col.IEnumerable<string> files,
-                                                                                      col.IEnumerable<FileAction> actions = null)
+                                                                                      col.IEnumerable<FileAction> actions = null,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var getFileMetadataBatchArg = new GetFileMetadataBatchArg(files,
                                                                       actions);
 
-            return this.GetFileMetadataBatchAsync(getFileMetadataBatchArg);
+            return this.GetFileMetadataBatchAsync(getFileMetadataBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -1067,14 +1098,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns shared folder metadata by its folder ID.</para>
         /// </summary>
         /// <param name="getMetadataArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharedFolderAccessError"/>.</exception>
-        public t.Task<SharedFolderMetadata> GetFolderMetadataAsync(GetMetadataArgs getMetadataArgs)
+        public t.Task<SharedFolderMetadata> GetFolderMetadataAsync(GetMetadataArgs getMetadataArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetMetadataArgs, SharedFolderMetadata, SharedFolderAccessError>(getMetadataArgs, "api", "/sharing/get_folder_metadata", "user", global::Dropbox.Api.Sharing.GetMetadataArgs.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.SharedFolderAccessError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetMetadataArgs, SharedFolderMetadata, SharedFolderAccessError>(getMetadataArgs, "api", "/sharing/get_folder_metadata", "user", global::Dropbox.Api.Sharing.GetMetadataArgs.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.SharedFolderAccessError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1101,18 +1133,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// `FolderPermission`s that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFolderMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharedFolderAccessError"/>.</exception>
         public t.Task<SharedFolderMetadata> GetFolderMetadataAsync(string sharedFolderId,
-                                                                   col.IEnumerable<FolderAction> actions = null)
+                                                                   col.IEnumerable<FolderAction> actions = null,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var getMetadataArgs = new GetMetadataArgs(sharedFolderId,
                                                       actions);
 
-            return this.GetFolderMetadataAsync(getMetadataArgs);
+            return this.GetFolderMetadataAsync(getMetadataArgs, cancellationToken);
         }
 
         /// <summary>
@@ -1164,14 +1198,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Download the shared link's file from a user's Dropbox.</para>
         /// </summary>
         /// <param name="getSharedLinkMetadataArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetSharedLinkFileError"/>.</exception>
-        public t.Task<enc.IDownloadResponse<SharedLinkMetadata>> GetSharedLinkFileAsync(GetSharedLinkMetadataArg getSharedLinkMetadataArg)
+        public t.Task<enc.IDownloadResponse<SharedLinkMetadata>> GetSharedLinkFileAsync(GetSharedLinkMetadataArg getSharedLinkMetadataArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendDownloadRequestAsync<GetSharedLinkMetadataArg, SharedLinkMetadata, GetSharedLinkFileError>(getSharedLinkMetadataArg, "content", "/sharing/get_shared_link_file", "user", global::Dropbox.Api.Sharing.GetSharedLinkMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.GetSharedLinkFileError.Decoder);
+            return this.Transport.SendDownloadRequestAsync<GetSharedLinkMetadataArg, SharedLinkMetadata, GetSharedLinkFileError>(getSharedLinkMetadataArg, "content", "/sharing/get_shared_link_file", "user", global::Dropbox.Api.Sharing.GetSharedLinkMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.GetSharedLinkFileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1199,6 +1234,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// path should be used.</param>
         /// <param name="linkPassword">If the shared link has a password, this parameter can be
         /// used.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1206,13 +1242,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="GetSharedLinkFileError"/>.</exception>
         public t.Task<enc.IDownloadResponse<SharedLinkMetadata>> GetSharedLinkFileAsync(string url,
                                                                                         string path = null,
-                                                                                        string linkPassword = null)
+                                                                                        string linkPassword = null,
+                                                                                        tr.CancellationToken cancellationToken = default)
         {
             var getSharedLinkMetadataArg = new GetSharedLinkMetadataArg(url,
                                                                         path,
                                                                         linkPassword);
 
-            return this.GetSharedLinkFileAsync(getSharedLinkMetadataArg);
+            return this.GetSharedLinkFileAsync(getSharedLinkMetadataArg, cancellationToken);
         }
 
         /// <summary>
@@ -1267,14 +1304,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Get the shared link's metadata.</para>
         /// </summary>
         /// <param name="getSharedLinkMetadataArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharedLinkError"/>.</exception>
-        public t.Task<SharedLinkMetadata> GetSharedLinkMetadataAsync(GetSharedLinkMetadataArg getSharedLinkMetadataArg)
+        public t.Task<SharedLinkMetadata> GetSharedLinkMetadataAsync(GetSharedLinkMetadataArg getSharedLinkMetadataArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetSharedLinkMetadataArg, SharedLinkMetadata, SharedLinkError>(getSharedLinkMetadataArg, "api", "/sharing/get_shared_link_metadata", "user", global::Dropbox.Api.Sharing.GetSharedLinkMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.SharedLinkError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetSharedLinkMetadataArg, SharedLinkMetadata, SharedLinkError>(getSharedLinkMetadataArg, "api", "/sharing/get_shared_link_metadata", "user", global::Dropbox.Api.Sharing.GetSharedLinkMetadataArg.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.SharedLinkError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1302,6 +1340,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// path should be used.</param>
         /// <param name="linkPassword">If the shared link has a password, this parameter can be
         /// used.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1309,13 +1348,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="SharedLinkError"/>.</exception>
         public t.Task<SharedLinkMetadata> GetSharedLinkMetadataAsync(string url,
                                                                      string path = null,
-                                                                     string linkPassword = null)
+                                                                     string linkPassword = null,
+                                                                     tr.CancellationToken cancellationToken = default)
         {
             var getSharedLinkMetadataArg = new GetSharedLinkMetadataArg(url,
                                                                         path,
                                                                         linkPassword);
 
-            return this.GetSharedLinkMetadataAsync(getSharedLinkMetadataArg);
+            return this.GetSharedLinkMetadataAsync(getSharedLinkMetadataArg, cancellationToken);
         }
 
         /// <summary>
@@ -1376,15 +1416,16 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Note that the url field in the response is never the shortened URL.</para>
         /// </summary>
         /// <param name="getSharedLinksArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetSharedLinksError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use ListSharedLinksAsync instead.")]
-        public t.Task<GetSharedLinksResult> GetSharedLinksAsync(GetSharedLinksArg getSharedLinksArg)
+        public t.Task<GetSharedLinksResult> GetSharedLinksAsync(GetSharedLinksArg getSharedLinksArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetSharedLinksArg, GetSharedLinksResult, GetSharedLinksError>(getSharedLinksArg, "api", "/sharing/get_shared_links", "user", global::Dropbox.Api.Sharing.GetSharedLinksArg.Encoder, global::Dropbox.Api.Sharing.GetSharedLinksResult.Decoder, global::Dropbox.Api.Sharing.GetSharedLinksError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetSharedLinksArg, GetSharedLinksResult, GetSharedLinksError>(getSharedLinksArg, "api", "/sharing/get_shared_links", "user", global::Dropbox.Api.Sharing.GetSharedLinksArg.Encoder, global::Dropbox.Api.Sharing.GetSharedLinksResult.Decoder, global::Dropbox.Api.Sharing.GetSharedLinksError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1416,17 +1457,19 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="path">See <see
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.GetSharedLinksAsync" />
         /// description.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetSharedLinksError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use ListSharedLinksAsync instead.")]
-        public t.Task<GetSharedLinksResult> GetSharedLinksAsync(string path = null)
+        public t.Task<GetSharedLinksResult> GetSharedLinksAsync(string path = null,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var getSharedLinksArg = new GetSharedLinksArg(path);
 
-            return this.GetSharedLinksAsync(getSharedLinksArg);
+            return this.GetSharedLinksAsync(getSharedLinksArg, cancellationToken);
         }
 
         /// <summary>
@@ -1477,14 +1520,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// uninherited members.</para>
         /// </summary>
         /// <param name="listFileMembersArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileMembersError"/>.</exception>
-        public t.Task<SharedFileMembers> ListFileMembersAsync(ListFileMembersArg listFileMembersArg)
+        public t.Task<SharedFileMembers> ListFileMembersAsync(ListFileMembersArg listFileMembersArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFileMembersArg, SharedFileMembers, ListFileMembersError>(listFileMembersArg, "api", "/sharing/list_file_members", "user", global::Dropbox.Api.Sharing.ListFileMembersArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMembers.Decoder, global::Dropbox.Api.Sharing.ListFileMembersError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFileMembersArg, SharedFileMembers, ListFileMembersError>(listFileMembersArg, "api", "/sharing/list_file_members", "user", global::Dropbox.Api.Sharing.ListFileMembersArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMembers.Decoder, global::Dropbox.Api.Sharing.ListFileMembersError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1514,6 +1558,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// a parent shared folder.</param>
         /// <param name="limit">Number of members to return max per query. Defaults to 100 if
         /// no limit is specified.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1522,14 +1567,15 @@ namespace Dropbox.Api.Sharing.Routes
         public t.Task<SharedFileMembers> ListFileMembersAsync(string file,
                                                               col.IEnumerable<MemberAction> actions = null,
                                                               bool includeInherited = true,
-                                                              uint limit = 100)
+                                                              uint limit = 100,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var listFileMembersArg = new ListFileMembersArg(file,
                                                             actions,
                                                             includeInherited,
                                                             limit);
 
-            return this.ListFileMembersAsync(listFileMembersArg);
+            return this.ListFileMembersAsync(listFileMembersArg, cancellationToken);
         }
 
         /// <summary>
@@ -1591,14 +1637,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// are not returned for this endpoint.</para>
         /// </summary>
         /// <param name="listFileMembersBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
-        public t.Task<col.List<ListFileMembersBatchResult>> ListFileMembersBatchAsync(ListFileMembersBatchArg listFileMembersBatchArg)
+        public t.Task<col.List<ListFileMembersBatchResult>> ListFileMembersBatchAsync(ListFileMembersBatchArg listFileMembersBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFileMembersBatchArg, col.List<ListFileMembersBatchResult>, SharingUserError>(listFileMembersBatchArg, "api", "/sharing/list_file_members/batch", "user", global::Dropbox.Api.Sharing.ListFileMembersBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.ListFileMembersBatchResult.Decoder), global::Dropbox.Api.Sharing.SharingUserError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFileMembersBatchArg, col.List<ListFileMembersBatchResult>, SharingUserError>(listFileMembersBatchArg, "api", "/sharing/list_file_members/batch", "user", global::Dropbox.Api.Sharing.ListFileMembersBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Sharing.ListFileMembersBatchResult.Decoder), global::Dropbox.Api.Sharing.SharingUserError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1627,18 +1674,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="files">Files for which to return members.</param>
         /// <param name="limit">Number of members to return max per query. Defaults to 10 if no
         /// limit is specified.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
         public t.Task<col.List<ListFileMembersBatchResult>> ListFileMembersBatchAsync(col.IEnumerable<string> files,
-                                                                                      uint limit = 10)
+                                                                                      uint limit = 10,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var listFileMembersBatchArg = new ListFileMembersBatchArg(files,
                                                                       limit);
 
-            return this.ListFileMembersBatchAsync(listFileMembersBatchArg);
+            return this.ListFileMembersBatchAsync(listFileMembersBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -1691,14 +1740,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// use this to paginate through all shared file members.</para>
         /// </summary>
         /// <param name="listFileMembersContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileMembersContinueError"/>.</exception>
-        public t.Task<SharedFileMembers> ListFileMembersContinueAsync(ListFileMembersContinueArg listFileMembersContinueArg)
+        public t.Task<SharedFileMembers> ListFileMembersContinueAsync(ListFileMembersContinueArg listFileMembersContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFileMembersContinueArg, SharedFileMembers, ListFileMembersContinueError>(listFileMembersContinueArg, "api", "/sharing/list_file_members/continue", "user", global::Dropbox.Api.Sharing.ListFileMembersContinueArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMembers.Decoder, global::Dropbox.Api.Sharing.ListFileMembersContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFileMembersContinueArg, SharedFileMembers, ListFileMembersContinueError>(listFileMembersContinueArg, "api", "/sharing/list_file_members/continue", "user", global::Dropbox.Api.Sharing.ListFileMembersContinueArg.Encoder, global::Dropbox.Api.Sharing.SharedFileMembers.Decoder, global::Dropbox.Api.Sharing.ListFileMembersContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1729,16 +1779,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// />, or <see
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.ListFileMembersBatchAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFileMembersContinueError"/>.</exception>
-        public t.Task<SharedFileMembers> ListFileMembersContinueAsync(string cursor)
+        public t.Task<SharedFileMembers> ListFileMembersContinueAsync(string cursor,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var listFileMembersContinueArg = new ListFileMembersContinueArg(cursor);
 
-            return this.ListFileMembersContinueAsync(listFileMembersContinueArg);
+            return this.ListFileMembersContinueAsync(listFileMembersContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -1789,14 +1841,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Returns shared folder membership by its folder ID.</para>
         /// </summary>
         /// <param name="listFolderMembersArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharedFolderAccessError"/>.</exception>
-        public t.Task<SharedFolderMembers> ListFolderMembersAsync(ListFolderMembersArgs listFolderMembersArgs)
+        public t.Task<SharedFolderMembers> ListFolderMembersAsync(ListFolderMembersArgs listFolderMembersArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderMembersArgs, SharedFolderMembers, SharedFolderAccessError>(listFolderMembersArgs, "api", "/sharing/list_folder_members", "user", global::Dropbox.Api.Sharing.ListFolderMembersArgs.Encoder, global::Dropbox.Api.Sharing.SharedFolderMembers.Decoder, global::Dropbox.Api.Sharing.SharedFolderAccessError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderMembersArgs, SharedFolderMembers, SharedFolderAccessError>(listFolderMembersArgs, "api", "/sharing/list_folder_members", "user", global::Dropbox.Api.Sharing.ListFolderMembersArgs.Encoder, global::Dropbox.Api.Sharing.SharedFolderMembers.Decoder, global::Dropbox.Api.Sharing.SharedFolderAccessError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1825,6 +1878,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// member.</param>
         /// <param name="limit">The maximum number of results that include members, groups and
         /// invitees to return per request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1832,13 +1886,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="SharedFolderAccessError"/>.</exception>
         public t.Task<SharedFolderMembers> ListFolderMembersAsync(string sharedFolderId,
                                                                   col.IEnumerable<MemberAction> actions = null,
-                                                                  uint limit = 1000)
+                                                                  uint limit = 1000,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listFolderMembersArgs = new ListFolderMembersArgs(sharedFolderId,
                                                                   actions,
                                                                   limit);
 
-            return this.ListFolderMembersAsync(listFolderMembersArgs);
+            return this.ListFolderMembersAsync(listFolderMembersArgs, cancellationToken);
         }
 
         /// <summary>
@@ -1896,14 +1951,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// this to paginate through all shared folder members.</para>
         /// </summary>
         /// <param name="listFolderMembersContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderMembersContinueError"/>.</exception>
-        public t.Task<SharedFolderMembers> ListFolderMembersContinueAsync(ListFolderMembersContinueArg listFolderMembersContinueArg)
+        public t.Task<SharedFolderMembers> ListFolderMembersContinueAsync(ListFolderMembersContinueArg listFolderMembersContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFolderMembersContinueArg, SharedFolderMembers, ListFolderMembersContinueError>(listFolderMembersContinueArg, "api", "/sharing/list_folder_members/continue", "user", global::Dropbox.Api.Sharing.ListFolderMembersContinueArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMembers.Decoder, global::Dropbox.Api.Sharing.ListFolderMembersContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFolderMembersContinueArg, SharedFolderMembers, ListFolderMembersContinueError>(listFolderMembersContinueArg, "api", "/sharing/list_folder_members/continue", "user", global::Dropbox.Api.Sharing.ListFolderMembersContinueArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMembers.Decoder, global::Dropbox.Api.Sharing.ListFolderMembersContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1932,16 +1988,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// <see
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.ListFolderMembersContinueAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFolderMembersContinueError"/>.</exception>
-        public t.Task<SharedFolderMembers> ListFolderMembersContinueAsync(string cursor)
+        public t.Task<SharedFolderMembers> ListFolderMembersContinueAsync(string cursor,
+                                                                          tr.CancellationToken cancellationToken = default)
         {
             var listFolderMembersContinueArg = new ListFolderMembersContinueArg(cursor);
 
-            return this.ListFolderMembersContinueAsync(listFolderMembersContinueArg);
+            return this.ListFolderMembersContinueAsync(listFolderMembersContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -1991,11 +2049,12 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Return the list of all shared folders the current user has access to.</para>
         /// </summary>
         /// <param name="listFoldersArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<ListFoldersResult> ListFoldersAsync(ListFoldersArgs listFoldersArgs)
+        public t.Task<ListFoldersResult> ListFoldersAsync(ListFoldersArgs listFoldersArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFoldersArgs, ListFoldersResult, enc.Empty>(listFoldersArgs, "api", "/sharing/list_folders", "user", global::Dropbox.Api.Sharing.ListFoldersArgs.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<ListFoldersArgs, ListFoldersResult, enc.Empty>(listFoldersArgs, "api", "/sharing/list_folders", "user", global::Dropbox.Api.Sharing.ListFoldersArgs.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -2022,15 +2081,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// `FolderPermission`s that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFolderMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<ListFoldersResult> ListFoldersAsync(uint limit = 1000,
-                                                          col.IEnumerable<FolderAction> actions = null)
+                                                          col.IEnumerable<FolderAction> actions = null,
+                                                          tr.CancellationToken cancellationToken = default)
         {
             var listFoldersArgs = new ListFoldersArgs(limit,
                                                       actions);
 
-            return this.ListFoldersAsync(listFoldersArgs);
+            return this.ListFoldersAsync(listFoldersArgs, cancellationToken);
         }
 
         /// <summary>
@@ -2084,14 +2145,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// />.</para>
         /// </summary>
         /// <param name="listFoldersContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFoldersContinueError"/>.</exception>
-        public t.Task<ListFoldersResult> ListFoldersContinueAsync(ListFoldersContinueArg listFoldersContinueArg)
+        public t.Task<ListFoldersResult> ListFoldersContinueAsync(ListFoldersContinueArg listFoldersContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFoldersContinueArg, ListFoldersResult, ListFoldersContinueError>(listFoldersContinueArg, "api", "/sharing/list_folders/continue", "user", global::Dropbox.Api.Sharing.ListFoldersContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, global::Dropbox.Api.Sharing.ListFoldersContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFoldersContinueArg, ListFoldersResult, ListFoldersContinueError>(listFoldersContinueArg, "api", "/sharing/list_folders/continue", "user", global::Dropbox.Api.Sharing.ListFoldersContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, global::Dropbox.Api.Sharing.ListFoldersContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2120,16 +2182,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="cursor">The cursor returned by the previous API call specified in the
         /// endpoint description.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFoldersContinueError"/>.</exception>
-        public t.Task<ListFoldersResult> ListFoldersContinueAsync(string cursor)
+        public t.Task<ListFoldersResult> ListFoldersContinueAsync(string cursor,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listFoldersContinueArg = new ListFoldersContinueArg(cursor);
 
-            return this.ListFoldersContinueAsync(listFoldersContinueArg);
+            return this.ListFoldersContinueAsync(listFoldersContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -2177,11 +2241,12 @@ namespace Dropbox.Api.Sharing.Routes
         /// unmount.</para>
         /// </summary>
         /// <param name="listFoldersArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<ListFoldersResult> ListMountableFoldersAsync(ListFoldersArgs listFoldersArgs)
+        public t.Task<ListFoldersResult> ListMountableFoldersAsync(ListFoldersArgs listFoldersArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFoldersArgs, ListFoldersResult, enc.Empty>(listFoldersArgs, "api", "/sharing/list_mountable_folders", "user", global::Dropbox.Api.Sharing.ListFoldersArgs.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<ListFoldersArgs, ListFoldersResult, enc.Empty>(listFoldersArgs, "api", "/sharing/list_mountable_folders", "user", global::Dropbox.Api.Sharing.ListFoldersArgs.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -2209,15 +2274,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// `FolderPermission`s that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFolderMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<ListFoldersResult> ListMountableFoldersAsync(uint limit = 1000,
-                                                                   col.IEnumerable<FolderAction> actions = null)
+                                                                   col.IEnumerable<FolderAction> actions = null,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var listFoldersArgs = new ListFoldersArgs(limit,
                                                       actions);
 
-            return this.ListMountableFoldersAsync(listFoldersArgs);
+            return this.ListMountableFoldersAsync(listFoldersArgs, cancellationToken);
         }
 
         /// <summary>
@@ -2273,14 +2340,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// />.</para>
         /// </summary>
         /// <param name="listFoldersContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFoldersContinueError"/>.</exception>
-        public t.Task<ListFoldersResult> ListMountableFoldersContinueAsync(ListFoldersContinueArg listFoldersContinueArg)
+        public t.Task<ListFoldersResult> ListMountableFoldersContinueAsync(ListFoldersContinueArg listFoldersContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFoldersContinueArg, ListFoldersResult, ListFoldersContinueError>(listFoldersContinueArg, "api", "/sharing/list_mountable_folders/continue", "user", global::Dropbox.Api.Sharing.ListFoldersContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, global::Dropbox.Api.Sharing.ListFoldersContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFoldersContinueArg, ListFoldersResult, ListFoldersContinueError>(listFoldersContinueArg, "api", "/sharing/list_mountable_folders/continue", "user", global::Dropbox.Api.Sharing.ListFoldersContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFoldersResult.Decoder, global::Dropbox.Api.Sharing.ListFoldersContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2312,16 +2380,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="cursor">The cursor returned by the previous API call specified in the
         /// endpoint description.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFoldersContinueError"/>.</exception>
-        public t.Task<ListFoldersResult> ListMountableFoldersContinueAsync(string cursor)
+        public t.Task<ListFoldersResult> ListMountableFoldersContinueAsync(string cursor,
+                                                                           tr.CancellationToken cancellationToken = default)
         {
             var listFoldersContinueArg = new ListFoldersContinueArg(cursor);
 
-            return this.ListMountableFoldersContinueAsync(listFoldersContinueArg);
+            return this.ListMountableFoldersContinueAsync(listFoldersContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -2371,14 +2441,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// not include unclaimed invitations.</para>
         /// </summary>
         /// <param name="listFilesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
-        public t.Task<ListFilesResult> ListReceivedFilesAsync(ListFilesArg listFilesArg)
+        public t.Task<ListFilesResult> ListReceivedFilesAsync(ListFilesArg listFilesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFilesArg, ListFilesResult, SharingUserError>(listFilesArg, "api", "/sharing/list_received_files", "user", global::Dropbox.Api.Sharing.ListFilesArg.Encoder, global::Dropbox.Api.Sharing.ListFilesResult.Decoder, global::Dropbox.Api.Sharing.SharingUserError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFilesArg, ListFilesResult, SharingUserError>(listFilesArg, "api", "/sharing/list_received_files", "user", global::Dropbox.Api.Sharing.ListFilesArg.Encoder, global::Dropbox.Api.Sharing.ListFilesResult.Decoder, global::Dropbox.Api.Sharing.SharingUserError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2408,18 +2479,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFileMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the file.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SharingUserError"/>.</exception>
         public t.Task<ListFilesResult> ListReceivedFilesAsync(uint limit = 100,
-                                                              col.IEnumerable<FileAction> actions = null)
+                                                              col.IEnumerable<FileAction> actions = null,
+                                                              tr.CancellationToken cancellationToken = default)
         {
             var listFilesArg = new ListFilesArg(limit,
                                                 actions);
 
-            return this.ListReceivedFilesAsync(listFilesArg);
+            return this.ListReceivedFilesAsync(listFilesArg, cancellationToken);
         }
 
         /// <summary>
@@ -2474,14 +2547,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// />.</para>
         /// </summary>
         /// <param name="listFilesContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFilesContinueError"/>.</exception>
-        public t.Task<ListFilesResult> ListReceivedFilesContinueAsync(ListFilesContinueArg listFilesContinueArg)
+        public t.Task<ListFilesResult> ListReceivedFilesContinueAsync(ListFilesContinueArg listFilesContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListFilesContinueArg, ListFilesResult, ListFilesContinueError>(listFilesContinueArg, "api", "/sharing/list_received_files/continue", "user", global::Dropbox.Api.Sharing.ListFilesContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFilesResult.Decoder, global::Dropbox.Api.Sharing.ListFilesContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListFilesContinueArg, ListFilesResult, ListFilesContinueError>(listFilesContinueArg, "api", "/sharing/list_received_files/continue", "user", global::Dropbox.Api.Sharing.ListFilesContinueArg.Encoder, global::Dropbox.Api.Sharing.ListFilesResult.Decoder, global::Dropbox.Api.Sharing.ListFilesContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2507,16 +2581,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// </summary>
         /// <param name="cursor">Cursor in <see
         /// cref="Dropbox.Api.Sharing.ListFilesResult.Cursor" />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListFilesContinueError"/>.</exception>
-        public t.Task<ListFilesResult> ListReceivedFilesContinueAsync(string cursor)
+        public t.Task<ListFilesResult> ListReceivedFilesContinueAsync(string cursor,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var listFilesContinueArg = new ListFilesContinueArg(cursor);
 
-            return this.ListReceivedFilesContinueAsync(listFilesContinueArg);
+            return this.ListReceivedFilesContinueAsync(listFilesContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -2573,14 +2649,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// direct_only to true.</para>
         /// </summary>
         /// <param name="listSharedLinksArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListSharedLinksError"/>.</exception>
-        public t.Task<ListSharedLinksResult> ListSharedLinksAsync(ListSharedLinksArg listSharedLinksArg)
+        public t.Task<ListSharedLinksResult> ListSharedLinksAsync(ListSharedLinksArg listSharedLinksArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListSharedLinksArg, ListSharedLinksResult, ListSharedLinksError>(listSharedLinksArg, "api", "/sharing/list_shared_links", "user", global::Dropbox.Api.Sharing.ListSharedLinksArg.Encoder, global::Dropbox.Api.Sharing.ListSharedLinksResult.Decoder, global::Dropbox.Api.Sharing.ListSharedLinksError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListSharedLinksArg, ListSharedLinksResult, ListSharedLinksError>(listSharedLinksArg, "api", "/sharing/list_shared_links", "user", global::Dropbox.Api.Sharing.ListSharedLinksArg.Encoder, global::Dropbox.Api.Sharing.ListSharedLinksResult.Decoder, global::Dropbox.Api.Sharing.ListSharedLinksError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2621,6 +2698,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="directOnly">See <see
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.ListSharedLinksAsync" />
         /// description.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2628,13 +2706,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="ListSharedLinksError"/>.</exception>
         public t.Task<ListSharedLinksResult> ListSharedLinksAsync(string path = null,
                                                                   string cursor = null,
-                                                                  bool? directOnly = null)
+                                                                  bool? directOnly = null,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listSharedLinksArg = new ListSharedLinksArg(path,
                                                             cursor,
                                                             directOnly);
 
-            return this.ListSharedLinksAsync(listSharedLinksArg);
+            return this.ListSharedLinksAsync(listSharedLinksArg, cancellationToken);
         }
 
         /// <summary>
@@ -2699,14 +2778,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// requested visibility.</para>
         /// </summary>
         /// <param name="modifySharedLinkSettingsArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ModifySharedLinkSettingsError"/>.</exception>
-        public t.Task<SharedLinkMetadata> ModifySharedLinkSettingsAsync(ModifySharedLinkSettingsArgs modifySharedLinkSettingsArgs)
+        public t.Task<SharedLinkMetadata> ModifySharedLinkSettingsAsync(ModifySharedLinkSettingsArgs modifySharedLinkSettingsArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ModifySharedLinkSettingsArgs, SharedLinkMetadata, ModifySharedLinkSettingsError>(modifySharedLinkSettingsArgs, "api", "/sharing/modify_shared_link_settings", "user", global::Dropbox.Api.Sharing.ModifySharedLinkSettingsArgs.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.ModifySharedLinkSettingsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ModifySharedLinkSettingsArgs, SharedLinkMetadata, ModifySharedLinkSettingsError>(modifySharedLinkSettingsArgs, "api", "/sharing/modify_shared_link_settings", "user", global::Dropbox.Api.Sharing.ModifySharedLinkSettingsArgs.Encoder, global::Dropbox.Api.Sharing.SharedLinkMetadata.Decoder, global::Dropbox.Api.Sharing.ModifySharedLinkSettingsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2739,6 +2819,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="settings">Set of settings for the shared link.</param>
         /// <param name="removeExpiration">If set to true, removes the expiration of the shared
         /// link.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2746,13 +2827,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="ModifySharedLinkSettingsError"/>.</exception>
         public t.Task<SharedLinkMetadata> ModifySharedLinkSettingsAsync(string url,
                                                                         SharedLinkSettings settings,
-                                                                        bool removeExpiration = false)
+                                                                        bool removeExpiration = false,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var modifySharedLinkSettingsArgs = new ModifySharedLinkSettingsArgs(url,
                                                                                 settings,
                                                                                 removeExpiration);
 
-            return this.ModifySharedLinkSettingsAsync(modifySharedLinkSettingsArgs);
+            return this.ModifySharedLinkSettingsAsync(modifySharedLinkSettingsArgs, cancellationToken);
         }
 
         /// <summary>
@@ -2807,14 +2889,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// mounted, the shared folder will appear in their Dropbox.</para>
         /// </summary>
         /// <param name="mountFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MountFolderError"/>.</exception>
-        public t.Task<SharedFolderMetadata> MountFolderAsync(MountFolderArg mountFolderArg)
+        public t.Task<SharedFolderMetadata> MountFolderAsync(MountFolderArg mountFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MountFolderArg, SharedFolderMetadata, MountFolderError>(mountFolderArg, "api", "/sharing/mount_folder", "user", global::Dropbox.Api.Sharing.MountFolderArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.MountFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MountFolderArg, SharedFolderMetadata, MountFolderError>(mountFolderArg, "api", "/sharing/mount_folder", "user", global::Dropbox.Api.Sharing.MountFolderArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.MountFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2839,16 +2922,18 @@ namespace Dropbox.Api.Sharing.Routes
         /// mounted, the shared folder will appear in their Dropbox.</para>
         /// </summary>
         /// <param name="sharedFolderId">The ID of the shared folder to mount.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MountFolderError"/>.</exception>
-        public t.Task<SharedFolderMetadata> MountFolderAsync(string sharedFolderId)
+        public t.Task<SharedFolderMetadata> MountFolderAsync(string sharedFolderId,
+                                                             tr.CancellationToken cancellationToken = default)
         {
             var mountFolderArg = new MountFolderArg(sharedFolderId);
 
-            return this.MountFolderAsync(mountFolderArg);
+            return this.MountFolderAsync(mountFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -2896,13 +2981,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// parent folder.</para>
         /// </summary>
         /// <param name="relinquishFileMembershipArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelinquishFileMembershipError"/>.</exception>
-        public t.Task RelinquishFileMembershipAsync(RelinquishFileMembershipArg relinquishFileMembershipArg)
+        public t.Task RelinquishFileMembershipAsync(RelinquishFileMembershipArg relinquishFileMembershipArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelinquishFileMembershipArg, enc.Empty, RelinquishFileMembershipError>(relinquishFileMembershipArg, "api", "/sharing/relinquish_file_membership", "user", global::Dropbox.Api.Sharing.RelinquishFileMembershipArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.RelinquishFileMembershipError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelinquishFileMembershipArg, enc.Empty, RelinquishFileMembershipError>(relinquishFileMembershipArg, "api", "/sharing/relinquish_file_membership", "user", global::Dropbox.Api.Sharing.RelinquishFileMembershipArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.RelinquishFileMembershipError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2927,15 +3013,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// parent folder.</para>
         /// </summary>
         /// <param name="file">The path or id for the file.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelinquishFileMembershipError"/>.</exception>
-        public t.Task RelinquishFileMembershipAsync(string file)
+        public t.Task RelinquishFileMembershipAsync(string file,
+                                                    tr.CancellationToken cancellationToken = default)
         {
             var relinquishFileMembershipArg = new RelinquishFileMembershipArg(file);
 
-            return this.RelinquishFileMembershipAsync(relinquishFileMembershipArg);
+            return this.RelinquishFileMembershipAsync(relinquishFileMembershipArg, cancellationToken);
         }
 
         /// <summary>
@@ -2982,14 +3070,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// leave_a_copy is true.</para>
         /// </summary>
         /// <param name="relinquishFolderMembershipArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelinquishFolderMembershipError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> RelinquishFolderMembershipAsync(RelinquishFolderMembershipArg relinquishFolderMembershipArg)
+        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> RelinquishFolderMembershipAsync(RelinquishFolderMembershipArg relinquishFolderMembershipArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RelinquishFolderMembershipArg, global::Dropbox.Api.Async.LaunchEmptyResult, RelinquishFolderMembershipError>(relinquishFolderMembershipArg, "api", "/sharing/relinquish_folder_membership", "user", global::Dropbox.Api.Sharing.RelinquishFolderMembershipArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Sharing.RelinquishFolderMembershipError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RelinquishFolderMembershipArg, global::Dropbox.Api.Async.LaunchEmptyResult, RelinquishFolderMembershipError>(relinquishFolderMembershipArg, "api", "/sharing/relinquish_folder_membership", "user", global::Dropbox.Api.Sharing.RelinquishFolderMembershipArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Sharing.RelinquishFolderMembershipError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3018,18 +3107,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="sharedFolderId">The ID for the shared folder.</param>
         /// <param name="leaveACopy">Keep a copy of the folder's contents upon relinquishing
         /// membership.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RelinquishFolderMembershipError"/>.</exception>
         public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> RelinquishFolderMembershipAsync(string sharedFolderId,
-                                                                                                   bool leaveACopy = false)
+                                                                                                   bool leaveACopy = false,
+                                                                                                   tr.CancellationToken cancellationToken = default)
         {
             var relinquishFolderMembershipArg = new RelinquishFolderMembershipArg(sharedFolderId,
                                                                                   leaveACopy);
 
-            return this.RelinquishFolderMembershipAsync(relinquishFolderMembershipArg);
+            return this.RelinquishFolderMembershipAsync(relinquishFolderMembershipArg, cancellationToken);
         }
 
         /// <summary>
@@ -3079,15 +3170,16 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Identical to remove_file_member_2 but with less information returned.</para>
         /// </summary>
         /// <param name="removeFileMemberArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemoveFileMemberError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use RemoveFileMember2Async instead.")]
-        public t.Task<FileMemberActionIndividualResult> RemoveFileMemberAsync(RemoveFileMemberArg removeFileMemberArg)
+        public t.Task<FileMemberActionIndividualResult> RemoveFileMemberAsync(RemoveFileMemberArg removeFileMemberArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemoveFileMemberArg, FileMemberActionIndividualResult, RemoveFileMemberError>(removeFileMemberArg, "api", "/sharing/remove_file_member", "user", global::Dropbox.Api.Sharing.RemoveFileMemberArg.Encoder, global::Dropbox.Api.Sharing.FileMemberActionIndividualResult.Decoder, global::Dropbox.Api.Sharing.RemoveFileMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemoveFileMemberArg, FileMemberActionIndividualResult, RemoveFileMemberError>(removeFileMemberArg, "api", "/sharing/remove_file_member", "user", global::Dropbox.Api.Sharing.RemoveFileMemberArg.Encoder, global::Dropbox.Api.Sharing.FileMemberActionIndividualResult.Decoder, global::Dropbox.Api.Sharing.RemoveFileMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3114,6 +3206,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="member">Member to remove from this file. Note that even if an email is
         /// specified, it may result in the removal of a user (not an invitee) if the user's
         /// main account corresponds to that email address.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3121,12 +3214,13 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="RemoveFileMemberError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use RemoveFileMember2Async instead.")]
         public t.Task<FileMemberActionIndividualResult> RemoveFileMemberAsync(string file,
-                                                                              MemberSelector member)
+                                                                              MemberSelector member,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var removeFileMemberArg = new RemoveFileMemberArg(file,
                                                               member);
 
-            return this.RemoveFileMemberAsync(removeFileMemberArg);
+            return this.RemoveFileMemberAsync(removeFileMemberArg, cancellationToken);
         }
 
         /// <summary>
@@ -3179,14 +3273,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Removes a specified member from the file.</para>
         /// </summary>
         /// <param name="removeFileMemberArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemoveFileMemberError"/>.</exception>
-        public t.Task<FileMemberRemoveActionResult> RemoveFileMember2Async(RemoveFileMemberArg removeFileMemberArg)
+        public t.Task<FileMemberRemoveActionResult> RemoveFileMember2Async(RemoveFileMemberArg removeFileMemberArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemoveFileMemberArg, FileMemberRemoveActionResult, RemoveFileMemberError>(removeFileMemberArg, "api", "/sharing/remove_file_member_2", "user", global::Dropbox.Api.Sharing.RemoveFileMemberArg.Encoder, global::Dropbox.Api.Sharing.FileMemberRemoveActionResult.Decoder, global::Dropbox.Api.Sharing.RemoveFileMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemoveFileMemberArg, FileMemberRemoveActionResult, RemoveFileMemberError>(removeFileMemberArg, "api", "/sharing/remove_file_member_2", "user", global::Dropbox.Api.Sharing.RemoveFileMemberArg.Encoder, global::Dropbox.Api.Sharing.FileMemberRemoveActionResult.Decoder, global::Dropbox.Api.Sharing.RemoveFileMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3212,18 +3307,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="member">Member to remove from this file. Note that even if an email is
         /// specified, it may result in the removal of a user (not an invitee) if the user's
         /// main account corresponds to that email address.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemoveFileMemberError"/>.</exception>
         public t.Task<FileMemberRemoveActionResult> RemoveFileMember2Async(string file,
-                                                                           MemberSelector member)
+                                                                           MemberSelector member,
+                                                                           tr.CancellationToken cancellationToken = default)
         {
             var removeFileMemberArg = new RemoveFileMemberArg(file,
                                                               member);
 
-            return this.RemoveFileMember2Async(removeFileMemberArg);
+            return this.RemoveFileMember2Async(removeFileMemberArg, cancellationToken);
         }
 
         /// <summary>
@@ -3275,14 +3372,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// folder to remove another member.</para>
         /// </summary>
         /// <param name="removeFolderMemberArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RemoveFolderMemberError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchResultBase> RemoveFolderMemberAsync(RemoveFolderMemberArg removeFolderMemberArg)
+        public t.Task<global::Dropbox.Api.Async.LaunchResultBase> RemoveFolderMemberAsync(RemoveFolderMemberArg removeFolderMemberArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RemoveFolderMemberArg, global::Dropbox.Api.Async.LaunchResultBase, RemoveFolderMemberError>(removeFolderMemberArg, "api", "/sharing/remove_folder_member", "user", global::Dropbox.Api.Sharing.RemoveFolderMemberArg.Encoder, global::Dropbox.Api.Async.LaunchResultBase.Decoder, global::Dropbox.Api.Sharing.RemoveFolderMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RemoveFolderMemberArg, global::Dropbox.Api.Async.LaunchResultBase, RemoveFolderMemberError>(removeFolderMemberArg, "api", "/sharing/remove_folder_member", "user", global::Dropbox.Api.Sharing.RemoveFolderMemberArg.Encoder, global::Dropbox.Api.Async.LaunchResultBase.Decoder, global::Dropbox.Api.Sharing.RemoveFolderMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3310,6 +3408,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="leaveACopy">If true, the removed user will keep their copy of the
         /// folder after it's unshared, assuming it was mounted. Otherwise, it will be removed
         /// from their Dropbox. Also, this must be set to false when kicking a group.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3317,13 +3416,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="RemoveFolderMemberError"/>.</exception>
         public t.Task<global::Dropbox.Api.Async.LaunchResultBase> RemoveFolderMemberAsync(string sharedFolderId,
                                                                                           MemberSelector member,
-                                                                                          bool leaveACopy)
+                                                                                          bool leaveACopy,
+                                                                                          tr.CancellationToken cancellationToken = default)
         {
             var removeFolderMemberArg = new RemoveFolderMemberArg(sharedFolderId,
                                                                   member,
                                                                   leaveACopy);
 
-            return this.RemoveFolderMemberAsync(removeFolderMemberArg);
+            return this.RemoveFolderMemberAsync(removeFolderMemberArg, cancellationToken);
         }
 
         /// <summary>
@@ -3383,13 +3483,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// argument.</para>
         /// </summary>
         /// <param name="revokeSharedLinkArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeSharedLinkError"/>.</exception>
-        public t.Task RevokeSharedLinkAsync(RevokeSharedLinkArg revokeSharedLinkArg)
+        public t.Task RevokeSharedLinkAsync(RevokeSharedLinkArg revokeSharedLinkArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RevokeSharedLinkArg, enc.Empty, RevokeSharedLinkError>(revokeSharedLinkArg, "api", "/sharing/revoke_shared_link", "user", global::Dropbox.Api.Sharing.RevokeSharedLinkArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.RevokeSharedLinkError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RevokeSharedLinkArg, enc.Empty, RevokeSharedLinkError>(revokeSharedLinkArg, "api", "/sharing/revoke_shared_link", "user", global::Dropbox.Api.Sharing.RevokeSharedLinkArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.RevokeSharedLinkError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3418,15 +3519,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// argument.</para>
         /// </summary>
         /// <param name="url">URL of the shared link.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeSharedLinkError"/>.</exception>
-        public t.Task RevokeSharedLinkAsync(string url)
+        public t.Task RevokeSharedLinkAsync(string url,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var revokeSharedLinkArg = new RevokeSharedLinkArg(url);
 
-            return this.RevokeSharedLinkAsync(revokeSharedLinkArg);
+            return this.RevokeSharedLinkAsync(revokeSharedLinkArg, cancellationToken);
         }
 
         /// <summary>
@@ -3474,14 +3577,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// until the action completes to get the metadata for the folder.</para>
         /// </summary>
         /// <param name="setAccessInheritanceArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetAccessInheritanceError"/>.</exception>
-        public t.Task<ShareFolderLaunch> SetAccessInheritanceAsync(SetAccessInheritanceArg setAccessInheritanceArg)
+        public t.Task<ShareFolderLaunch> SetAccessInheritanceAsync(SetAccessInheritanceArg setAccessInheritanceArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SetAccessInheritanceArg, ShareFolderLaunch, SetAccessInheritanceError>(setAccessInheritanceArg, "api", "/sharing/set_access_inheritance", "user", global::Dropbox.Api.Sharing.SetAccessInheritanceArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderLaunch.Decoder, global::Dropbox.Api.Sharing.SetAccessInheritanceError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SetAccessInheritanceArg, ShareFolderLaunch, SetAccessInheritanceError>(setAccessInheritanceArg, "api", "/sharing/set_access_inheritance", "user", global::Dropbox.Api.Sharing.SetAccessInheritanceArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderLaunch.Decoder, global::Dropbox.Api.Sharing.SetAccessInheritanceError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3511,18 +3615,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="sharedFolderId">The ID for the shared folder.</param>
         /// <param name="accessInheritance">The access inheritance settings for the
         /// folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetAccessInheritanceError"/>.</exception>
         public t.Task<ShareFolderLaunch> SetAccessInheritanceAsync(string sharedFolderId,
-                                                                   AccessInheritance accessInheritance = null)
+                                                                   AccessInheritance accessInheritance = null,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var setAccessInheritanceArg = new SetAccessInheritanceArg(sharedFolderId,
                                                                       accessInheritance);
 
-            return this.SetAccessInheritanceAsync(setAccessInheritanceArg);
+            return this.SetAccessInheritanceAsync(setAccessInheritanceArg, cancellationToken);
         }
 
         /// <summary>
@@ -3579,14 +3685,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// until the action completes to get the metadata for the folder.</para>
         /// </summary>
         /// <param name="shareFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ShareFolderError"/>.</exception>
-        public t.Task<ShareFolderLaunch> ShareFolderAsync(ShareFolderArg shareFolderArg)
+        public t.Task<ShareFolderLaunch> ShareFolderAsync(ShareFolderArg shareFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ShareFolderArg, ShareFolderLaunch, ShareFolderError>(shareFolderArg, "api", "/sharing/share_folder", "user", global::Dropbox.Api.Sharing.ShareFolderArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderLaunch.Decoder, global::Dropbox.Api.Sharing.ShareFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ShareFolderArg, ShareFolderLaunch, ShareFolderError>(shareFolderArg, "api", "/sharing/share_folder", "user", global::Dropbox.Api.Sharing.ShareFolderArg.Encoder, global::Dropbox.Api.Sharing.ShareFolderLaunch.Decoder, global::Dropbox.Api.Sharing.ShareFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3635,6 +3742,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="Dropbox.Api.Sharing.SharedFolderMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the folder.</param>
         /// <param name="linkSettings">Settings on the link for this folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -3648,7 +3756,8 @@ namespace Dropbox.Api.Sharing.Routes
                                                           ViewerInfoPolicy viewerInfoPolicy = null,
                                                           AccessInheritance accessInheritance = null,
                                                           col.IEnumerable<FolderAction> actions = null,
-                                                          LinkSettings linkSettings = null)
+                                                          LinkSettings linkSettings = null,
+                                                          tr.CancellationToken cancellationToken = default)
         {
             var shareFolderArg = new ShareFolderArg(path,
                                                     aclUpdatePolicy,
@@ -3660,7 +3769,7 @@ namespace Dropbox.Api.Sharing.Routes
                                                     actions,
                                                     linkSettings);
 
-            return this.ShareFolderAsync(shareFolderArg);
+            return this.ShareFolderAsync(shareFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -3744,13 +3853,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// the shared folder to perform a transfer.</para>
         /// </summary>
         /// <param name="transferFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TransferFolderError"/>.</exception>
-        public t.Task TransferFolderAsync(TransferFolderArg transferFolderArg)
+        public t.Task TransferFolderAsync(TransferFolderArg transferFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TransferFolderArg, enc.Empty, TransferFolderError>(transferFolderArg, "api", "/sharing/transfer_folder", "user", global::Dropbox.Api.Sharing.TransferFolderArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.TransferFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TransferFolderArg, enc.Empty, TransferFolderError>(transferFolderArg, "api", "/sharing/transfer_folder", "user", global::Dropbox.Api.Sharing.TransferFolderArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.TransferFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3778,17 +3888,19 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="sharedFolderId">The ID for the shared folder.</param>
         /// <param name="toDropboxId">A account or team member ID to transfer ownership
         /// to.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TransferFolderError"/>.</exception>
         public t.Task TransferFolderAsync(string sharedFolderId,
-                                          string toDropboxId)
+                                          string toDropboxId,
+                                          tr.CancellationToken cancellationToken = default)
         {
             var transferFolderArg = new TransferFolderArg(sharedFolderId,
                                                           toDropboxId);
 
-            return this.TransferFolderAsync(transferFolderArg);
+            return this.TransferFolderAsync(transferFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -3837,13 +3949,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.MountFolderAsync" />.</para>
         /// </summary>
         /// <param name="unmountFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnmountFolderError"/>.</exception>
-        public t.Task UnmountFolderAsync(UnmountFolderArg unmountFolderArg)
+        public t.Task UnmountFolderAsync(UnmountFolderArg unmountFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UnmountFolderArg, enc.Empty, UnmountFolderError>(unmountFolderArg, "api", "/sharing/unmount_folder", "user", global::Dropbox.Api.Sharing.UnmountFolderArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.UnmountFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UnmountFolderArg, enc.Empty, UnmountFolderError>(unmountFolderArg, "api", "/sharing/unmount_folder", "user", global::Dropbox.Api.Sharing.UnmountFolderArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.UnmountFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3868,15 +3981,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="Dropbox.Api.Sharing.Routes.SharingUserRoutes.MountFolderAsync" />.</para>
         /// </summary>
         /// <param name="sharedFolderId">The ID for the shared folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnmountFolderError"/>.</exception>
-        public t.Task UnmountFolderAsync(string sharedFolderId)
+        public t.Task UnmountFolderAsync(string sharedFolderId,
+                                         tr.CancellationToken cancellationToken = default)
         {
             var unmountFolderArg = new UnmountFolderArg(sharedFolderId);
 
-            return this.UnmountFolderAsync(unmountFolderArg);
+            return this.UnmountFolderAsync(unmountFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -3919,13 +4034,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Remove all members from this file. Does not remove inherited members.</para>
         /// </summary>
         /// <param name="unshareFileArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnshareFileError"/>.</exception>
-        public t.Task UnshareFileAsync(UnshareFileArg unshareFileArg)
+        public t.Task UnshareFileAsync(UnshareFileArg unshareFileArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UnshareFileArg, enc.Empty, UnshareFileError>(unshareFileArg, "api", "/sharing/unshare_file", "user", global::Dropbox.Api.Sharing.UnshareFileArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.UnshareFileError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UnshareFileArg, enc.Empty, UnshareFileError>(unshareFileArg, "api", "/sharing/unshare_file", "user", global::Dropbox.Api.Sharing.UnshareFileArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Sharing.UnshareFileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3948,15 +4064,17 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Remove all members from this file. Does not remove inherited members.</para>
         /// </summary>
         /// <param name="file">The file to unshare.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnshareFileError"/>.</exception>
-        public t.Task UnshareFileAsync(string file)
+        public t.Task UnshareFileAsync(string file,
+                                       tr.CancellationToken cancellationToken = default)
         {
             var unshareFileArg = new UnshareFileArg(file);
 
-            return this.UnshareFileAsync(unshareFileArg);
+            return this.UnshareFileAsync(unshareFileArg, cancellationToken);
         }
 
         /// <summary>
@@ -4002,14 +4120,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// determine if the action has completed successfully.</para>
         /// </summary>
         /// <param name="unshareFolderArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnshareFolderError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> UnshareFolderAsync(UnshareFolderArg unshareFolderArg)
+        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> UnshareFolderAsync(UnshareFolderArg unshareFolderArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UnshareFolderArg, global::Dropbox.Api.Async.LaunchEmptyResult, UnshareFolderError>(unshareFolderArg, "api", "/sharing/unshare_folder", "user", global::Dropbox.Api.Sharing.UnshareFolderArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Sharing.UnshareFolderError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UnshareFolderArg, global::Dropbox.Api.Async.LaunchEmptyResult, UnshareFolderError>(unshareFolderArg, "api", "/sharing/unshare_folder", "user", global::Dropbox.Api.Sharing.UnshareFolderArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Sharing.UnshareFolderError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4038,18 +4157,20 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="leaveACopy">If true, members of this shared folder will get a copy of
         /// this folder after it's unshared. Otherwise, it will be removed from their Dropbox.
         /// The current user, who is an owner, will always retain their copy.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UnshareFolderError"/>.</exception>
         public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> UnshareFolderAsync(string sharedFolderId,
-                                                                                      bool leaveACopy = false)
+                                                                                      bool leaveACopy = false,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var unshareFolderArg = new UnshareFolderArg(sharedFolderId,
                                                         leaveACopy);
 
-            return this.UnshareFolderAsync(unshareFolderArg);
+            return this.UnshareFolderAsync(unshareFolderArg, cancellationToken);
         }
 
         /// <summary>
@@ -4100,14 +4221,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// <para>Changes a member's access on a shared file.</para>
         /// </summary>
         /// <param name="updateFileMemberArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="FileMemberActionError"/>.</exception>
-        public t.Task<MemberAccessLevelResult> UpdateFileMemberAsync(UpdateFileMemberArgs updateFileMemberArgs)
+        public t.Task<MemberAccessLevelResult> UpdateFileMemberAsync(UpdateFileMemberArgs updateFileMemberArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateFileMemberArgs, MemberAccessLevelResult, FileMemberActionError>(updateFileMemberArgs, "api", "/sharing/update_file_member", "user", global::Dropbox.Api.Sharing.UpdateFileMemberArgs.Encoder, global::Dropbox.Api.Sharing.MemberAccessLevelResult.Decoder, global::Dropbox.Api.Sharing.FileMemberActionError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateFileMemberArgs, MemberAccessLevelResult, FileMemberActionError>(updateFileMemberArgs, "api", "/sharing/update_file_member", "user", global::Dropbox.Api.Sharing.UpdateFileMemberArgs.Encoder, global::Dropbox.Api.Sharing.MemberAccessLevelResult.Decoder, global::Dropbox.Api.Sharing.FileMemberActionError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4132,6 +4254,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// <param name="file">File for which we are changing a member's access.</param>
         /// <param name="member">The member whose access we are changing.</param>
         /// <param name="accessLevel">The new access level for the member.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4139,13 +4262,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="FileMemberActionError"/>.</exception>
         public t.Task<MemberAccessLevelResult> UpdateFileMemberAsync(string file,
                                                                      MemberSelector member,
-                                                                     AccessLevel accessLevel)
+                                                                     AccessLevel accessLevel,
+                                                                     tr.CancellationToken cancellationToken = default)
         {
             var updateFileMemberArgs = new UpdateFileMemberArgs(file,
                                                                 member,
                                                                 accessLevel);
 
-            return this.UpdateFileMemberAsync(updateFileMemberArgs);
+            return this.UpdateFileMemberAsync(updateFileMemberArgs, cancellationToken);
         }
 
         /// <summary>
@@ -4198,14 +4322,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// permissions.</para>
         /// </summary>
         /// <param name="updateFolderMemberArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UpdateFolderMemberError"/>.</exception>
-        public t.Task<MemberAccessLevelResult> UpdateFolderMemberAsync(UpdateFolderMemberArg updateFolderMemberArg)
+        public t.Task<MemberAccessLevelResult> UpdateFolderMemberAsync(UpdateFolderMemberArg updateFolderMemberArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateFolderMemberArg, MemberAccessLevelResult, UpdateFolderMemberError>(updateFolderMemberArg, "api", "/sharing/update_folder_member", "user", global::Dropbox.Api.Sharing.UpdateFolderMemberArg.Encoder, global::Dropbox.Api.Sharing.MemberAccessLevelResult.Decoder, global::Dropbox.Api.Sharing.UpdateFolderMemberError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateFolderMemberArg, MemberAccessLevelResult, UpdateFolderMemberError>(updateFolderMemberArg, "api", "/sharing/update_folder_member", "user", global::Dropbox.Api.Sharing.UpdateFolderMemberArg.Encoder, global::Dropbox.Api.Sharing.MemberAccessLevelResult.Decoder, global::Dropbox.Api.Sharing.UpdateFolderMemberError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4234,6 +4359,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// time.</param>
         /// <param name="accessLevel">The new access level for <paramref name="member" />. <see
         /// cref="Dropbox.Api.Sharing.AccessLevel.Owner" /> is disallowed.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4241,13 +4367,14 @@ namespace Dropbox.Api.Sharing.Routes
         /// cref="UpdateFolderMemberError"/>.</exception>
         public t.Task<MemberAccessLevelResult> UpdateFolderMemberAsync(string sharedFolderId,
                                                                        MemberSelector member,
-                                                                       AccessLevel accessLevel)
+                                                                       AccessLevel accessLevel,
+                                                                       tr.CancellationToken cancellationToken = default)
         {
             var updateFolderMemberArg = new UpdateFolderMemberArg(sharedFolderId,
                                                                   member,
                                                                   accessLevel);
 
-            return this.UpdateFolderMemberAsync(updateFolderMemberArg);
+            return this.UpdateFolderMemberAsync(updateFolderMemberArg, cancellationToken);
         }
 
         /// <summary>
@@ -4304,14 +4431,15 @@ namespace Dropbox.Api.Sharing.Routes
         /// the shared folder to update its policies.</para>
         /// </summary>
         /// <param name="updateFolderPolicyArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UpdateFolderPolicyError"/>.</exception>
-        public t.Task<SharedFolderMetadata> UpdateFolderPolicyAsync(UpdateFolderPolicyArg updateFolderPolicyArg)
+        public t.Task<SharedFolderMetadata> UpdateFolderPolicyAsync(UpdateFolderPolicyArg updateFolderPolicyArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UpdateFolderPolicyArg, SharedFolderMetadata, UpdateFolderPolicyError>(updateFolderPolicyArg, "api", "/sharing/update_folder_policy", "user", global::Dropbox.Api.Sharing.UpdateFolderPolicyArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.UpdateFolderPolicyError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UpdateFolderPolicyArg, SharedFolderMetadata, UpdateFolderPolicyError>(updateFolderPolicyArg, "api", "/sharing/update_folder_policy", "user", global::Dropbox.Api.Sharing.UpdateFolderPolicyArg.Encoder, global::Dropbox.Api.Sharing.SharedFolderMetadata.Decoder, global::Dropbox.Api.Sharing.UpdateFolderPolicyError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4350,6 +4478,7 @@ namespace Dropbox.Api.Sharing.Routes
         /// `FolderPermission`s that should appear in the  response's <see
         /// cref="Dropbox.Api.Sharing.SharedFolderMetadata.Permissions" /> field describing the
         /// actions the  authenticated user can perform on the folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4361,7 +4490,8 @@ namespace Dropbox.Api.Sharing.Routes
                                                                     ViewerInfoPolicy viewerInfoPolicy = null,
                                                                     SharedLinkPolicy sharedLinkPolicy = null,
                                                                     LinkSettings linkSettings = null,
-                                                                    col.IEnumerable<FolderAction> actions = null)
+                                                                    col.IEnumerable<FolderAction> actions = null,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var updateFolderPolicyArg = new UpdateFolderPolicyArg(sharedFolderId,
                                                                   memberPolicy,
@@ -4371,7 +4501,7 @@ namespace Dropbox.Api.Sharing.Routes
                                                                   linkSettings,
                                                                   actions);
 
-            return this.UpdateFolderPolicyAsync(updateFolderPolicyArg);
+            return this.UpdateFolderPolicyAsync(updateFolderPolicyArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Team/TeamTeamRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Team/TeamTeamRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Team.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -33,14 +34,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>List all device sessions of a team's member.</para>
         /// </summary>
         /// <param name="listMemberDevicesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMemberDevicesError"/>.</exception>
-        public t.Task<ListMemberDevicesResult> DevicesListMemberDevicesAsync(ListMemberDevicesArg listMemberDevicesArg)
+        public t.Task<ListMemberDevicesResult> DevicesListMemberDevicesAsync(ListMemberDevicesArg listMemberDevicesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListMemberDevicesArg, ListMemberDevicesResult, ListMemberDevicesError>(listMemberDevicesArg, "api", "/team/devices/list_member_devices", "team", global::Dropbox.Api.Team.ListMemberDevicesArg.Encoder, global::Dropbox.Api.Team.ListMemberDevicesResult.Decoder, global::Dropbox.Api.Team.ListMemberDevicesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListMemberDevicesArg, ListMemberDevicesResult, ListMemberDevicesError>(listMemberDevicesArg, "api", "/team/devices/list_member_devices", "team", global::Dropbox.Api.Team.ListMemberDevicesArg.Encoder, global::Dropbox.Api.Team.ListMemberDevicesResult.Decoder, global::Dropbox.Api.Team.ListMemberDevicesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace Dropbox.Api.Team.Routes
         /// team's member.</param>
         /// <param name="includeMobileClients">Whether to list linked mobile devices of the
         /// team's member.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -77,14 +80,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<ListMemberDevicesResult> DevicesListMemberDevicesAsync(string teamMemberId,
                                                                              bool includeWebSessions = true,
                                                                              bool includeDesktopClients = true,
-                                                                             bool includeMobileClients = true)
+                                                                             bool includeMobileClients = true,
+                                                                             tr.CancellationToken cancellationToken = default)
         {
             var listMemberDevicesArg = new ListMemberDevicesArg(teamMemberId,
                                                                 includeWebSessions,
                                                                 includeDesktopClients,
                                                                 includeMobileClients);
 
-            return this.DevicesListMemberDevicesAsync(listMemberDevicesArg);
+            return this.DevicesListMemberDevicesAsync(listMemberDevicesArg, cancellationToken);
         }
 
         /// <summary>
@@ -143,14 +147,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="listMembersDevicesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMembersDevicesError"/>.</exception>
-        public t.Task<ListMembersDevicesResult> DevicesListMembersDevicesAsync(ListMembersDevicesArg listMembersDevicesArg)
+        public t.Task<ListMembersDevicesResult> DevicesListMembersDevicesAsync(ListMembersDevicesArg listMembersDevicesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListMembersDevicesArg, ListMembersDevicesResult, ListMembersDevicesError>(listMembersDevicesArg, "api", "/team/devices/list_members_devices", "team", global::Dropbox.Api.Team.ListMembersDevicesArg.Encoder, global::Dropbox.Api.Team.ListMembersDevicesResult.Decoder, global::Dropbox.Api.Team.ListMembersDevicesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListMembersDevicesArg, ListMembersDevicesResult, ListMembersDevicesError>(listMembersDevicesArg, "api", "/team/devices/list_members_devices", "team", global::Dropbox.Api.Team.ListMembersDevicesArg.Encoder, global::Dropbox.Api.Team.ListMembersDevicesResult.Decoder, global::Dropbox.Api.Team.ListMembersDevicesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -184,6 +189,7 @@ namespace Dropbox.Api.Team.Routes
         /// members.</param>
         /// <param name="includeMobileClients">Whether to list mobile clients of the team
         /// members.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -192,14 +198,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<ListMembersDevicesResult> DevicesListMembersDevicesAsync(string cursor = null,
                                                                                bool includeWebSessions = true,
                                                                                bool includeDesktopClients = true,
-                                                                               bool includeMobileClients = true)
+                                                                               bool includeMobileClients = true,
+                                                                               tr.CancellationToken cancellationToken = default)
         {
             var listMembersDevicesArg = new ListMembersDevicesArg(cursor,
                                                                   includeWebSessions,
                                                                   includeDesktopClients,
                                                                   includeMobileClients);
 
-            return this.DevicesListMembersDevicesAsync(listMembersDevicesArg);
+            return this.DevicesListMembersDevicesAsync(listMembersDevicesArg, cancellationToken);
         }
 
         /// <summary>
@@ -262,15 +269,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="listTeamDevicesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListTeamDevicesError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use DevicesListMembersDevicesAsync instead.")]
-        public t.Task<ListTeamDevicesResult> DevicesListTeamDevicesAsync(ListTeamDevicesArg listTeamDevicesArg)
+        public t.Task<ListTeamDevicesResult> DevicesListTeamDevicesAsync(ListTeamDevicesArg listTeamDevicesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListTeamDevicesArg, ListTeamDevicesResult, ListTeamDevicesError>(listTeamDevicesArg, "api", "/team/devices/list_team_devices", "team", global::Dropbox.Api.Team.ListTeamDevicesArg.Encoder, global::Dropbox.Api.Team.ListTeamDevicesResult.Decoder, global::Dropbox.Api.Team.ListTeamDevicesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListTeamDevicesArg, ListTeamDevicesResult, ListTeamDevicesError>(listTeamDevicesArg, "api", "/team/devices/list_team_devices", "team", global::Dropbox.Api.Team.ListTeamDevicesArg.Encoder, global::Dropbox.Api.Team.ListTeamDevicesResult.Decoder, global::Dropbox.Api.Team.ListTeamDevicesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -305,6 +313,7 @@ namespace Dropbox.Api.Team.Routes
         /// members.</param>
         /// <param name="includeMobileClients">Whether to list mobile clients of the team
         /// members.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -314,14 +323,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<ListTeamDevicesResult> DevicesListTeamDevicesAsync(string cursor = null,
                                                                          bool includeWebSessions = true,
                                                                          bool includeDesktopClients = true,
-                                                                         bool includeMobileClients = true)
+                                                                         bool includeMobileClients = true,
+                                                                         tr.CancellationToken cancellationToken = default)
         {
             var listTeamDevicesArg = new ListTeamDevicesArg(cursor,
                                                             includeWebSessions,
                                                             includeDesktopClients,
                                                             includeMobileClients);
 
-            return this.DevicesListTeamDevicesAsync(listTeamDevicesArg);
+            return this.DevicesListTeamDevicesAsync(listTeamDevicesArg, cancellationToken);
         }
 
         /// <summary>
@@ -385,13 +395,14 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a device session of a team's member.</para>
         /// </summary>
         /// <param name="revokeDeviceSessionArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeDeviceSessionError"/>.</exception>
-        public t.Task DevicesRevokeDeviceSessionAsync(RevokeDeviceSessionArg revokeDeviceSessionArg)
+        public t.Task DevicesRevokeDeviceSessionAsync(RevokeDeviceSessionArg revokeDeviceSessionArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RevokeDeviceSessionArg, enc.Empty, RevokeDeviceSessionError>(revokeDeviceSessionArg, "api", "/team/devices/revoke_device_session", "team", global::Dropbox.Api.Team.RevokeDeviceSessionArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.RevokeDeviceSessionError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RevokeDeviceSessionArg, enc.Empty, RevokeDeviceSessionError>(revokeDeviceSessionArg, "api", "/team/devices/revoke_device_session", "team", global::Dropbox.Api.Team.RevokeDeviceSessionArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.RevokeDeviceSessionError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -433,14 +444,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a list of device sessions of team members.</para>
         /// </summary>
         /// <param name="revokeDeviceSessionBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeDeviceSessionBatchError"/>.</exception>
-        public t.Task<RevokeDeviceSessionBatchResult> DevicesRevokeDeviceSessionBatchAsync(RevokeDeviceSessionBatchArg revokeDeviceSessionBatchArg)
+        public t.Task<RevokeDeviceSessionBatchResult> DevicesRevokeDeviceSessionBatchAsync(RevokeDeviceSessionBatchArg revokeDeviceSessionBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RevokeDeviceSessionBatchArg, RevokeDeviceSessionBatchResult, RevokeDeviceSessionBatchError>(revokeDeviceSessionBatchArg, "api", "/team/devices/revoke_device_session_batch", "team", global::Dropbox.Api.Team.RevokeDeviceSessionBatchArg.Encoder, global::Dropbox.Api.Team.RevokeDeviceSessionBatchResult.Decoder, global::Dropbox.Api.Team.RevokeDeviceSessionBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RevokeDeviceSessionBatchArg, RevokeDeviceSessionBatchResult, RevokeDeviceSessionBatchError>(revokeDeviceSessionBatchArg, "api", "/team/devices/revoke_device_session_batch", "team", global::Dropbox.Api.Team.RevokeDeviceSessionBatchArg.Encoder, global::Dropbox.Api.Team.RevokeDeviceSessionBatchResult.Decoder, global::Dropbox.Api.Team.RevokeDeviceSessionBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -464,16 +476,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a list of device sessions of team members.</para>
         /// </summary>
         /// <param name="revokeDevices">The revoke devices</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeDeviceSessionBatchError"/>.</exception>
-        public t.Task<RevokeDeviceSessionBatchResult> DevicesRevokeDeviceSessionBatchAsync(col.IEnumerable<RevokeDeviceSessionArg> revokeDevices)
+        public t.Task<RevokeDeviceSessionBatchResult> DevicesRevokeDeviceSessionBatchAsync(col.IEnumerable<RevokeDeviceSessionArg> revokeDevices,
+                                                                                           tr.CancellationToken cancellationToken = default)
         {
             var revokeDeviceSessionBatchArg = new RevokeDeviceSessionBatchArg(revokeDevices);
 
-            return this.DevicesRevokeDeviceSessionBatchAsync(revokeDeviceSessionBatchArg);
+            return this.DevicesRevokeDeviceSessionBatchAsync(revokeDeviceSessionBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -523,14 +537,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team information.</para>
         /// </summary>
         /// <param name="featuresGetValuesBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="FeaturesGetValuesBatchError"/>.</exception>
-        public t.Task<FeaturesGetValuesBatchResult> FeaturesGetValuesAsync(FeaturesGetValuesBatchArg featuresGetValuesBatchArg)
+        public t.Task<FeaturesGetValuesBatchResult> FeaturesGetValuesAsync(FeaturesGetValuesBatchArg featuresGetValuesBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<FeaturesGetValuesBatchArg, FeaturesGetValuesBatchResult, FeaturesGetValuesBatchError>(featuresGetValuesBatchArg, "api", "/team/features/get_values", "team", global::Dropbox.Api.Team.FeaturesGetValuesBatchArg.Encoder, global::Dropbox.Api.Team.FeaturesGetValuesBatchResult.Decoder, global::Dropbox.Api.Team.FeaturesGetValuesBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<FeaturesGetValuesBatchArg, FeaturesGetValuesBatchResult, FeaturesGetValuesBatchError>(featuresGetValuesBatchArg, "api", "/team/features/get_values", "team", global::Dropbox.Api.Team.FeaturesGetValuesBatchArg.Encoder, global::Dropbox.Api.Team.FeaturesGetValuesBatchResult.Decoder, global::Dropbox.Api.Team.FeaturesGetValuesBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -557,16 +572,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="features">A list of features in <see cref="Feature" />. If the list is
         /// empty, this route will return <see cref="FeaturesGetValuesBatchError" />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="FeaturesGetValuesBatchError"/>.</exception>
-        public t.Task<FeaturesGetValuesBatchResult> FeaturesGetValuesAsync(col.IEnumerable<Feature> features)
+        public t.Task<FeaturesGetValuesBatchResult> FeaturesGetValuesAsync(col.IEnumerable<Feature> features,
+                                                                           tr.CancellationToken cancellationToken = default)
         {
             var featuresGetValuesBatchArg = new FeaturesGetValuesBatchArg(features);
 
-            return this.FeaturesGetValuesAsync(featuresGetValuesBatchArg);
+            return this.FeaturesGetValuesAsync(featuresGetValuesBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -612,11 +629,12 @@ namespace Dropbox.Api.Team.Routes
         /// <summary>
         /// <para>Retrieves information about a team.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<TeamGetInfoResult> GetInfoAsync()
+        public t.Task<TeamGetInfoResult> GetInfoAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, TeamGetInfoResult, enc.Empty>(enc.Empty.Instance, "api", "/team/get_info", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.Team.TeamGetInfoResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, TeamGetInfoResult, enc.Empty>(enc.Empty.Instance, "api", "/team/get_info", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.Team.TeamGetInfoResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -657,14 +675,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupCreateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupCreateError"/>.</exception>
-        public t.Task<GroupFullInfo> GroupsCreateAsync(GroupCreateArg groupCreateArg)
+        public t.Task<GroupFullInfo> GroupsCreateAsync(GroupCreateArg groupCreateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupCreateArg, GroupFullInfo, GroupCreateError>(groupCreateArg, "api", "/team/groups/create", "team", global::Dropbox.Api.Team.GroupCreateArg.Encoder, global::Dropbox.Api.Team.GroupFullInfo.Decoder, global::Dropbox.Api.Team.GroupCreateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupCreateArg, GroupFullInfo, GroupCreateError>(groupCreateArg, "api", "/team/groups/create", "team", global::Dropbox.Api.Team.GroupCreateArg.Encoder, global::Dropbox.Api.Team.GroupFullInfo.Decoder, global::Dropbox.Api.Team.GroupCreateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -693,6 +712,7 @@ namespace Dropbox.Api.Team.Routes
         /// external ID to the group.</param>
         /// <param name="groupManagementType">Whether the team can be managed by selected
         /// users, or only by team admins.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -701,14 +721,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<GroupFullInfo> GroupsCreateAsync(string groupName,
                                                        bool addCreatorAsOwner = false,
                                                        string groupExternalId = null,
-                                                       global::Dropbox.Api.TeamCommon.GroupManagementType groupManagementType = null)
+                                                       global::Dropbox.Api.TeamCommon.GroupManagementType groupManagementType = null,
+                                                       tr.CancellationToken cancellationToken = default)
         {
             var groupCreateArg = new GroupCreateArg(groupName,
                                                     addCreatorAsOwner,
                                                     groupExternalId,
                                                     groupManagementType);
 
-            return this.GroupsCreateAsync(groupCreateArg);
+            return this.GroupsCreateAsync(groupCreateArg, cancellationToken);
         }
 
         /// <summary>
@@ -770,14 +791,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupSelector">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupDeleteError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> GroupsDeleteAsync(GroupSelector groupSelector)
+        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> GroupsDeleteAsync(GroupSelector groupSelector, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupSelector, global::Dropbox.Api.Async.LaunchEmptyResult, GroupDeleteError>(groupSelector, "api", "/team/groups/delete", "team", global::Dropbox.Api.Team.GroupSelector.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.GroupDeleteError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupSelector, global::Dropbox.Api.Async.LaunchEmptyResult, GroupDeleteError>(groupSelector, "api", "/team/groups/delete", "team", global::Dropbox.Api.Team.GroupSelector.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.GroupDeleteError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -824,14 +846,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team Information.</para>
         /// </summary>
         /// <param name="groupsSelector">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsGetInfoError"/>.</exception>
-        public t.Task<col.List<GroupsGetInfoItem>> GroupsGetInfoAsync(GroupsSelector groupsSelector)
+        public t.Task<col.List<GroupsGetInfoItem>> GroupsGetInfoAsync(GroupsSelector groupsSelector, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupsSelector, col.List<GroupsGetInfoItem>, GroupsGetInfoError>(groupsSelector, "api", "/team/groups/get_info", "team", global::Dropbox.Api.Team.GroupsSelector.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.GroupsGetInfoItem.Decoder), global::Dropbox.Api.Team.GroupsGetInfoError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupsSelector, col.List<GroupsGetInfoItem>, GroupsGetInfoError>(groupsSelector, "api", "/team/groups/get_info", "team", global::Dropbox.Api.Team.GroupsSelector.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.GroupsGetInfoItem.Decoder), global::Dropbox.Api.Team.GroupsGetInfoError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -881,14 +904,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsPollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> GroupsJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> GroupsJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, GroupsPollError>(pollArg, "api", "/team/groups/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Team.GroupsPollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, GroupsPollError>(pollArg, "api", "/team/groups/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Team.GroupsPollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -918,16 +942,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsPollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> GroupsJobStatusGetAsync(string asyncJobId)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> GroupsJobStatusGetAsync(string asyncJobId,
+                                                                                         tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.GroupsJobStatusGetAsync(pollArg);
+            return this.GroupsJobStatusGetAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -975,11 +1001,12 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team Information.</para>
         /// </summary>
         /// <param name="groupsListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<GroupsListResult> GroupsListAsync(GroupsListArg groupsListArg)
+        public t.Task<GroupsListResult> GroupsListAsync(GroupsListArg groupsListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupsListArg, GroupsListResult, enc.Empty>(groupsListArg, "api", "/team/groups/list", "team", global::Dropbox.Api.Team.GroupsListArg.Encoder, global::Dropbox.Api.Team.GroupsListResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<GroupsListArg, GroupsListResult, enc.Empty>(groupsListArg, "api", "/team/groups/list", "team", global::Dropbox.Api.Team.GroupsListArg.Encoder, global::Dropbox.Api.Team.GroupsListResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -1003,13 +1030,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team Information.</para>
         /// </summary>
         /// <param name="limit">Number of results to return per call.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<GroupsListResult> GroupsListAsync(uint limit = 1000)
+        public t.Task<GroupsListResult> GroupsListAsync(uint limit = 1000,
+                                                        tr.CancellationToken cancellationToken = default)
         {
             var groupsListArg = new GroupsListArg(limit);
 
-            return this.GroupsListAsync(groupsListArg);
+            return this.GroupsListAsync(groupsListArg, cancellationToken);
         }
 
         /// <summary>
@@ -1055,14 +1084,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team Information.</para>
         /// </summary>
         /// <param name="groupsListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsListContinueError"/>.</exception>
-        public t.Task<GroupsListResult> GroupsListContinueAsync(GroupsListContinueArg groupsListContinueArg)
+        public t.Task<GroupsListResult> GroupsListContinueAsync(GroupsListContinueArg groupsListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupsListContinueArg, GroupsListResult, GroupsListContinueError>(groupsListContinueArg, "api", "/team/groups/list/continue", "team", global::Dropbox.Api.Team.GroupsListContinueArg.Encoder, global::Dropbox.Api.Team.GroupsListResult.Decoder, global::Dropbox.Api.Team.GroupsListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupsListContinueArg, GroupsListResult, GroupsListContinueError>(groupsListContinueArg, "api", "/team/groups/list/continue", "team", global::Dropbox.Api.Team.GroupsListContinueArg.Encoder, global::Dropbox.Api.Team.GroupsListResult.Decoder, global::Dropbox.Api.Team.GroupsListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1089,16 +1119,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// groups.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsListContinueError"/>.</exception>
-        public t.Task<GroupsListResult> GroupsListContinueAsync(string cursor)
+        public t.Task<GroupsListResult> GroupsListContinueAsync(string cursor,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var groupsListContinueArg = new GroupsListContinueArg(cursor);
 
-            return this.GroupsListContinueAsync(groupsListContinueArg);
+            return this.GroupsListContinueAsync(groupsListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -1150,14 +1182,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupMembersAddArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupMembersAddError"/>.</exception>
-        public t.Task<GroupMembersChangeResult> GroupsMembersAddAsync(GroupMembersAddArg groupMembersAddArg)
+        public t.Task<GroupMembersChangeResult> GroupsMembersAddAsync(GroupMembersAddArg groupMembersAddArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupMembersAddArg, GroupMembersChangeResult, GroupMembersAddError>(groupMembersAddArg, "api", "/team/groups/members/add", "team", global::Dropbox.Api.Team.GroupMembersAddArg.Encoder, global::Dropbox.Api.Team.GroupMembersChangeResult.Decoder, global::Dropbox.Api.Team.GroupMembersAddError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupMembersAddArg, GroupMembersChangeResult, GroupMembersAddError>(groupMembersAddArg, "api", "/team/groups/members/add", "team", global::Dropbox.Api.Team.GroupMembersAddArg.Encoder, global::Dropbox.Api.Team.GroupMembersChangeResult.Decoder, global::Dropbox.Api.Team.GroupMembersAddError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1189,6 +1222,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="returnMembers">Whether to return the list of members in the group.
         /// Note that the default value will cause all the group members  to be returned in the
         /// response. This may take a long time for large groups.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1196,13 +1230,14 @@ namespace Dropbox.Api.Team.Routes
         /// cref="GroupMembersAddError"/>.</exception>
         public t.Task<GroupMembersChangeResult> GroupsMembersAddAsync(GroupSelector @group,
                                                                       col.IEnumerable<MemberAccess> members,
-                                                                      bool returnMembers = true)
+                                                                      bool returnMembers = true,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var groupMembersAddArg = new GroupMembersAddArg(@group,
                                                             members,
                                                             returnMembers);
 
-            return this.GroupsMembersAddAsync(groupMembersAddArg);
+            return this.GroupsMembersAddAsync(groupMembersAddArg, cancellationToken);
         }
 
         /// <summary>
@@ -1257,14 +1292,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team Information.</para>
         /// </summary>
         /// <param name="groupsMembersListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupSelectorError"/>.</exception>
-        public t.Task<GroupsMembersListResult> GroupsMembersListAsync(GroupsMembersListArg groupsMembersListArg)
+        public t.Task<GroupsMembersListResult> GroupsMembersListAsync(GroupsMembersListArg groupsMembersListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupsMembersListArg, GroupsMembersListResult, GroupSelectorError>(groupsMembersListArg, "api", "/team/groups/members/list", "team", global::Dropbox.Api.Team.GroupsMembersListArg.Encoder, global::Dropbox.Api.Team.GroupsMembersListResult.Decoder, global::Dropbox.Api.Team.GroupSelectorError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupsMembersListArg, GroupsMembersListResult, GroupSelectorError>(groupsMembersListArg, "api", "/team/groups/members/list", "team", global::Dropbox.Api.Team.GroupsMembersListArg.Encoder, global::Dropbox.Api.Team.GroupsMembersListResult.Decoder, global::Dropbox.Api.Team.GroupSelectorError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1289,18 +1325,20 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="group">The group whose members are to be listed.</param>
         /// <param name="limit">Number of results to return per call.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupSelectorError"/>.</exception>
         public t.Task<GroupsMembersListResult> GroupsMembersListAsync(GroupSelector @group,
-                                                                      uint limit = 1000)
+                                                                      uint limit = 1000,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var groupsMembersListArg = new GroupsMembersListArg(@group,
                                                                 limit);
 
-            return this.GroupsMembersListAsync(groupsMembersListArg);
+            return this.GroupsMembersListAsync(groupsMembersListArg, cancellationToken);
         }
 
         /// <summary>
@@ -1352,14 +1390,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team information.</para>
         /// </summary>
         /// <param name="groupsMembersListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsMembersListContinueError"/>.</exception>
-        public t.Task<GroupsMembersListResult> GroupsMembersListContinueAsync(GroupsMembersListContinueArg groupsMembersListContinueArg)
+        public t.Task<GroupsMembersListResult> GroupsMembersListContinueAsync(GroupsMembersListContinueArg groupsMembersListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupsMembersListContinueArg, GroupsMembersListResult, GroupsMembersListContinueError>(groupsMembersListContinueArg, "api", "/team/groups/members/list/continue", "team", global::Dropbox.Api.Team.GroupsMembersListContinueArg.Encoder, global::Dropbox.Api.Team.GroupsMembersListResult.Decoder, global::Dropbox.Api.Team.GroupsMembersListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupsMembersListContinueArg, GroupsMembersListResult, GroupsMembersListContinueError>(groupsMembersListContinueArg, "api", "/team/groups/members/list/continue", "team", global::Dropbox.Api.Team.GroupsMembersListContinueArg.Encoder, global::Dropbox.Api.Team.GroupsMembersListResult.Decoder, global::Dropbox.Api.Team.GroupsMembersListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1386,16 +1425,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// groups.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupsMembersListContinueError"/>.</exception>
-        public t.Task<GroupsMembersListResult> GroupsMembersListContinueAsync(string cursor)
+        public t.Task<GroupsMembersListResult> GroupsMembersListContinueAsync(string cursor,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var groupsMembersListContinueArg = new GroupsMembersListContinueArg(cursor);
 
-            return this.GroupsMembersListContinueAsync(groupsMembersListContinueArg);
+            return this.GroupsMembersListContinueAsync(groupsMembersListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -1449,14 +1490,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupMembersRemoveArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupMembersRemoveError"/>.</exception>
-        public t.Task<GroupMembersChangeResult> GroupsMembersRemoveAsync(GroupMembersRemoveArg groupMembersRemoveArg)
+        public t.Task<GroupMembersChangeResult> GroupsMembersRemoveAsync(GroupMembersRemoveArg groupMembersRemoveArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupMembersRemoveArg, GroupMembersChangeResult, GroupMembersRemoveError>(groupMembersRemoveArg, "api", "/team/groups/members/remove", "team", global::Dropbox.Api.Team.GroupMembersRemoveArg.Encoder, global::Dropbox.Api.Team.GroupMembersChangeResult.Decoder, global::Dropbox.Api.Team.GroupMembersRemoveError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupMembersRemoveArg, GroupMembersChangeResult, GroupMembersRemoveError>(groupMembersRemoveArg, "api", "/team/groups/members/remove", "team", global::Dropbox.Api.Team.GroupMembersRemoveArg.Encoder, global::Dropbox.Api.Team.GroupMembersChangeResult.Decoder, global::Dropbox.Api.Team.GroupMembersRemoveError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1490,6 +1532,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="returnMembers">Whether to return the list of members in the group.
         /// Note that the default value will cause all the group members  to be returned in the
         /// response. This may take a long time for large groups.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1497,13 +1540,14 @@ namespace Dropbox.Api.Team.Routes
         /// cref="GroupMembersRemoveError"/>.</exception>
         public t.Task<GroupMembersChangeResult> GroupsMembersRemoveAsync(GroupSelector @group,
                                                                          col.IEnumerable<UserSelectorArg> users,
-                                                                         bool returnMembers = true)
+                                                                         bool returnMembers = true,
+                                                                         tr.CancellationToken cancellationToken = default)
         {
             var groupMembersRemoveArg = new GroupMembersRemoveArg(@group,
                                                                   users,
                                                                   returnMembers);
 
-            return this.GroupsMembersRemoveAsync(groupMembersRemoveArg);
+            return this.GroupsMembersRemoveAsync(groupMembersRemoveArg, cancellationToken);
         }
 
         /// <summary>
@@ -1558,14 +1602,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupMembersSetAccessTypeArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupMemberSetAccessTypeError"/>.</exception>
-        public t.Task<col.List<GroupsGetInfoItem>> GroupsMembersSetAccessTypeAsync(GroupMembersSetAccessTypeArg groupMembersSetAccessTypeArg)
+        public t.Task<col.List<GroupsGetInfoItem>> GroupsMembersSetAccessTypeAsync(GroupMembersSetAccessTypeArg groupMembersSetAccessTypeArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupMembersSetAccessTypeArg, col.List<GroupsGetInfoItem>, GroupMemberSetAccessTypeError>(groupMembersSetAccessTypeArg, "api", "/team/groups/members/set_access_type", "team", global::Dropbox.Api.Team.GroupMembersSetAccessTypeArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.GroupsGetInfoItem.Decoder), global::Dropbox.Api.Team.GroupMemberSetAccessTypeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupMembersSetAccessTypeArg, col.List<GroupsGetInfoItem>, GroupMemberSetAccessTypeError>(groupMembersSetAccessTypeArg, "api", "/team/groups/members/set_access_type", "team", global::Dropbox.Api.Team.GroupMembersSetAccessTypeArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.GroupsGetInfoItem.Decoder), global::Dropbox.Api.Team.GroupMemberSetAccessTypeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1596,6 +1641,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="returnMembers">Whether to return the list of members in the group.
         /// Note that the default value will cause all the group members  to be returned in the
         /// response. This may take a long time for large groups.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1604,14 +1650,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<col.List<GroupsGetInfoItem>> GroupsMembersSetAccessTypeAsync(GroupSelector @group,
                                                                                    UserSelectorArg user,
                                                                                    GroupAccessType accessType,
-                                                                                   bool returnMembers = true)
+                                                                                   bool returnMembers = true,
+                                                                                   tr.CancellationToken cancellationToken = default)
         {
             var groupMembersSetAccessTypeArg = new GroupMembersSetAccessTypeArg(@group,
                                                                                 user,
                                                                                 accessType,
                                                                                 returnMembers);
 
-            return this.GroupsMembersSetAccessTypeAsync(groupMembersSetAccessTypeArg);
+            return this.GroupsMembersSetAccessTypeAsync(groupMembersSetAccessTypeArg, cancellationToken);
         }
 
         /// <summary>
@@ -1671,14 +1718,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="groupUpdateArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GroupUpdateError"/>.</exception>
-        public t.Task<GroupFullInfo> GroupsUpdateAsync(GroupUpdateArgs groupUpdateArgs)
+        public t.Task<GroupFullInfo> GroupsUpdateAsync(GroupUpdateArgs groupUpdateArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GroupUpdateArgs, GroupFullInfo, GroupUpdateError>(groupUpdateArgs, "api", "/team/groups/update", "team", global::Dropbox.Api.Team.GroupUpdateArgs.Encoder, global::Dropbox.Api.Team.GroupFullInfo.Decoder, global::Dropbox.Api.Team.GroupUpdateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GroupUpdateArgs, GroupFullInfo, GroupUpdateError>(groupUpdateArgs, "api", "/team/groups/update", "team", global::Dropbox.Api.Team.GroupUpdateArgs.Encoder, global::Dropbox.Api.Team.GroupFullInfo.Decoder, global::Dropbox.Api.Team.GroupUpdateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1712,6 +1760,7 @@ namespace Dropbox.Api.Team.Routes
         /// empty string, the group's external id will be cleared.</param>
         /// <param name="newGroupManagementType">Set new group management type, if
         /// provided.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1721,7 +1770,8 @@ namespace Dropbox.Api.Team.Routes
                                                        bool returnMembers = true,
                                                        string newGroupName = null,
                                                        string newGroupExternalId = null,
-                                                       global::Dropbox.Api.TeamCommon.GroupManagementType newGroupManagementType = null)
+                                                       global::Dropbox.Api.TeamCommon.GroupManagementType newGroupManagementType = null,
+                                                       tr.CancellationToken cancellationToken = default)
         {
             var groupUpdateArgs = new GroupUpdateArgs(@group,
                                                       returnMembers,
@@ -1729,7 +1779,7 @@ namespace Dropbox.Api.Team.Routes
                                                       newGroupExternalId,
                                                       newGroupManagementType);
 
-            return this.GroupsUpdateAsync(groupUpdateArgs);
+            return this.GroupsUpdateAsync(groupUpdateArgs, cancellationToken);
         }
 
         /// <summary>
@@ -1795,14 +1845,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsPolicyCreateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsPolicyCreateError"/>.</exception>
-        public t.Task<LegalHoldPolicy> LegalHoldsCreatePolicyAsync(LegalHoldsPolicyCreateArg legalHoldsPolicyCreateArg)
+        public t.Task<LegalHoldPolicy> LegalHoldsCreatePolicyAsync(LegalHoldsPolicyCreateArg legalHoldsPolicyCreateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyCreateArg, LegalHoldPolicy, LegalHoldsPolicyCreateError>(legalHoldsPolicyCreateArg, "api", "/team/legal_holds/create_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyCreateArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsPolicyCreateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyCreateArg, LegalHoldPolicy, LegalHoldsPolicyCreateError>(legalHoldsPolicyCreateArg, "api", "/team/legal_holds/create_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyCreateArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsPolicyCreateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1831,6 +1882,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="description">A description of the legal hold policy.</param>
         /// <param name="startDate">start date of the legal hold policy.</param>
         /// <param name="endDate">end date of the legal hold policy.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -1840,7 +1892,8 @@ namespace Dropbox.Api.Team.Routes
                                                                    col.IEnumerable<string> members,
                                                                    string description = null,
                                                                    sys.DateTime? startDate = null,
-                                                                   sys.DateTime? endDate = null)
+                                                                   sys.DateTime? endDate = null,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsPolicyCreateArg = new LegalHoldsPolicyCreateArg(name,
                                                                           members,
@@ -1848,7 +1901,7 @@ namespace Dropbox.Api.Team.Routes
                                                                           startDate,
                                                                           endDate);
 
-            return this.LegalHoldsCreatePolicyAsync(legalHoldsPolicyCreateArg);
+            return this.LegalHoldsCreatePolicyAsync(legalHoldsPolicyCreateArg, cancellationToken);
         }
 
         /// <summary>
@@ -1908,14 +1961,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsGetPolicyArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsGetPolicyError"/>.</exception>
-        public t.Task<LegalHoldPolicy> LegalHoldsGetPolicyAsync(LegalHoldsGetPolicyArg legalHoldsGetPolicyArg)
+        public t.Task<LegalHoldPolicy> LegalHoldsGetPolicyAsync(LegalHoldsGetPolicyArg legalHoldsGetPolicyArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsGetPolicyArg, LegalHoldPolicy, LegalHoldsGetPolicyError>(legalHoldsGetPolicyArg, "api", "/team/legal_holds/get_policy", "team", global::Dropbox.Api.Team.LegalHoldsGetPolicyArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsGetPolicyError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsGetPolicyArg, LegalHoldPolicy, LegalHoldsGetPolicyError>(legalHoldsGetPolicyArg, "api", "/team/legal_holds/get_policy", "team", global::Dropbox.Api.Team.LegalHoldsGetPolicyArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsGetPolicyError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -1940,16 +1994,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="id">The legal hold Id.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsGetPolicyError"/>.</exception>
-        public t.Task<LegalHoldPolicy> LegalHoldsGetPolicyAsync(string id)
+        public t.Task<LegalHoldPolicy> LegalHoldsGetPolicyAsync(string id,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsGetPolicyArg = new LegalHoldsGetPolicyArg(id);
 
-            return this.LegalHoldsGetPolicyAsync(legalHoldsGetPolicyArg);
+            return this.LegalHoldsGetPolicyAsync(legalHoldsGetPolicyArg, cancellationToken);
         }
 
         /// <summary>
@@ -1997,14 +2053,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsListHeldRevisionsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListHeldRevisionsError"/>.</exception>
-        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsAsync(LegalHoldsListHeldRevisionsArg legalHoldsListHeldRevisionsArg)
+        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsAsync(LegalHoldsListHeldRevisionsArg legalHoldsListHeldRevisionsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsListHeldRevisionsArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>(legalHoldsListHeldRevisionsArg, "api", "/team/legal_holds/list_held_revisions", "team", global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsListHeldRevisionsArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>(legalHoldsListHeldRevisionsArg, "api", "/team/legal_holds/list_held_revisions", "team", global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2030,16 +2087,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="id">The legal hold Id.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListHeldRevisionsError"/>.</exception>
-        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsAsync(string id)
+        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsAsync(string id,
+                                                                                         tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsListHeldRevisionsArg = new LegalHoldsListHeldRevisionsArg(id);
 
-            return this.LegalHoldsListHeldRevisionsAsync(legalHoldsListHeldRevisionsArg);
+            return this.LegalHoldsListHeldRevisionsAsync(legalHoldsListHeldRevisionsArg, cancellationToken);
         }
 
         /// <summary>
@@ -2088,14 +2147,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsListHeldRevisionsContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListHeldRevisionsError"/>.</exception>
-        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsContinueAsync(LegalHoldsListHeldRevisionsContinueArg legalHoldsListHeldRevisionsContinueArg)
+        public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsContinueAsync(LegalHoldsListHeldRevisionsContinueArg legalHoldsListHeldRevisionsContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsListHeldRevisionsContinueArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>(legalHoldsListHeldRevisionsContinueArg, "api", "/team/legal_holds/list_held_revisions_continue", "team", global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsContinueArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsListHeldRevisionsContinueArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>(legalHoldsListHeldRevisionsContinueArg, "api", "/team/legal_holds/list_held_revisions_continue", "team", global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsContinueArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListHeldRevisionsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2125,18 +2185,20 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="cursor">The cursor idicates where to continue reading file metadata
         /// entries for the next API call. When there are no more entries, the cursor will
         /// return none.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListHeldRevisionsError"/>.</exception>
         public t.Task<LegalHoldsListHeldRevisionResult> LegalHoldsListHeldRevisionsContinueAsync(string id,
-                                                                                                 string cursor = null)
+                                                                                                 string cursor = null,
+                                                                                                 tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsListHeldRevisionsContinueArg = new LegalHoldsListHeldRevisionsContinueArg(id,
                                                                                                     cursor);
 
-            return this.LegalHoldsListHeldRevisionsContinueAsync(legalHoldsListHeldRevisionsContinueArg);
+            return this.LegalHoldsListHeldRevisionsContinueAsync(legalHoldsListHeldRevisionsContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -2190,14 +2252,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsListPoliciesArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListPoliciesError"/>.</exception>
-        public t.Task<LegalHoldsListPoliciesResult> LegalHoldsListPoliciesAsync(LegalHoldsListPoliciesArg legalHoldsListPoliciesArg)
+        public t.Task<LegalHoldsListPoliciesResult> LegalHoldsListPoliciesAsync(LegalHoldsListPoliciesArg legalHoldsListPoliciesArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsListPoliciesArg, LegalHoldsListPoliciesResult, LegalHoldsListPoliciesError>(legalHoldsListPoliciesArg, "api", "/team/legal_holds/list_policies", "team", global::Dropbox.Api.Team.LegalHoldsListPoliciesArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListPoliciesResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListPoliciesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsListPoliciesArg, LegalHoldsListPoliciesResult, LegalHoldsListPoliciesError>(legalHoldsListPoliciesArg, "api", "/team/legal_holds/list_policies", "team", global::Dropbox.Api.Team.LegalHoldsListPoliciesArg.Encoder, global::Dropbox.Api.Team.LegalHoldsListPoliciesResult.Decoder, global::Dropbox.Api.Team.LegalHoldsListPoliciesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2222,16 +2285,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="includeReleased">Whether to return holds that were released.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsListPoliciesError"/>.</exception>
-        public t.Task<LegalHoldsListPoliciesResult> LegalHoldsListPoliciesAsync(bool includeReleased = false)
+        public t.Task<LegalHoldsListPoliciesResult> LegalHoldsListPoliciesAsync(bool includeReleased = false,
+                                                                                tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsListPoliciesArg = new LegalHoldsListPoliciesArg(includeReleased);
 
-            return this.LegalHoldsListPoliciesAsync(legalHoldsListPoliciesArg);
+            return this.LegalHoldsListPoliciesAsync(legalHoldsListPoliciesArg, cancellationToken);
         }
 
         /// <summary>
@@ -2279,13 +2344,14 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsPolicyReleaseArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsPolicyReleaseError"/>.</exception>
-        public t.Task LegalHoldsReleasePolicyAsync(LegalHoldsPolicyReleaseArg legalHoldsPolicyReleaseArg)
+        public t.Task LegalHoldsReleasePolicyAsync(LegalHoldsPolicyReleaseArg legalHoldsPolicyReleaseArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyReleaseArg, enc.Empty, LegalHoldsPolicyReleaseError>(legalHoldsPolicyReleaseArg, "api", "/team/legal_holds/release_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyReleaseArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.LegalHoldsPolicyReleaseError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyReleaseArg, enc.Empty, LegalHoldsPolicyReleaseError>(legalHoldsPolicyReleaseArg, "api", "/team/legal_holds/release_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyReleaseArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.LegalHoldsPolicyReleaseError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2310,15 +2376,17 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="id">The legal hold Id.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsPolicyReleaseError"/>.</exception>
-        public t.Task LegalHoldsReleasePolicyAsync(string id)
+        public t.Task LegalHoldsReleasePolicyAsync(string id,
+                                                   tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsPolicyReleaseArg = new LegalHoldsPolicyReleaseArg(id);
 
-            return this.LegalHoldsReleasePolicyAsync(legalHoldsPolicyReleaseArg);
+            return this.LegalHoldsReleasePolicyAsync(legalHoldsPolicyReleaseArg, cancellationToken);
         }
 
         /// <summary>
@@ -2363,14 +2431,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="legalHoldsPolicyUpdateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="LegalHoldsPolicyUpdateError"/>.</exception>
-        public t.Task<LegalHoldPolicy> LegalHoldsUpdatePolicyAsync(LegalHoldsPolicyUpdateArg legalHoldsPolicyUpdateArg)
+        public t.Task<LegalHoldPolicy> LegalHoldsUpdatePolicyAsync(LegalHoldsPolicyUpdateArg legalHoldsPolicyUpdateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyUpdateArg, LegalHoldPolicy, LegalHoldsPolicyUpdateError>(legalHoldsPolicyUpdateArg, "api", "/team/legal_holds/update_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyUpdateArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsPolicyUpdateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<LegalHoldsPolicyUpdateArg, LegalHoldPolicy, LegalHoldsPolicyUpdateError>(legalHoldsPolicyUpdateArg, "api", "/team/legal_holds/update_policy", "team", global::Dropbox.Api.Team.LegalHoldsPolicyUpdateArg.Encoder, global::Dropbox.Api.Team.LegalHoldPolicy.Decoder, global::Dropbox.Api.Team.LegalHoldsPolicyUpdateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2398,6 +2467,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="name">Policy new name.</param>
         /// <param name="description">Policy new description.</param>
         /// <param name="members">List of team member IDs to apply the policy on.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -2406,14 +2476,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<LegalHoldPolicy> LegalHoldsUpdatePolicyAsync(string id,
                                                                    string name = null,
                                                                    string description = null,
-                                                                   col.IEnumerable<string> members = null)
+                                                                   col.IEnumerable<string> members = null,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var legalHoldsPolicyUpdateArg = new LegalHoldsPolicyUpdateArg(id,
                                                                           name,
                                                                           description,
                                                                           members);
 
-            return this.LegalHoldsUpdatePolicyAsync(legalHoldsPolicyUpdateArg);
+            return this.LegalHoldsUpdatePolicyAsync(legalHoldsPolicyUpdateArg, cancellationToken);
         }
 
         /// <summary>
@@ -2469,14 +2540,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Note, this endpoint does not list any team-linked applications.</para>
         /// </summary>
         /// <param name="listMemberAppsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMemberAppsError"/>.</exception>
-        public t.Task<ListMemberAppsResult> LinkedAppsListMemberLinkedAppsAsync(ListMemberAppsArg listMemberAppsArg)
+        public t.Task<ListMemberAppsResult> LinkedAppsListMemberLinkedAppsAsync(ListMemberAppsArg listMemberAppsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListMemberAppsArg, ListMemberAppsResult, ListMemberAppsError>(listMemberAppsArg, "api", "/team/linked_apps/list_member_linked_apps", "team", global::Dropbox.Api.Team.ListMemberAppsArg.Encoder, global::Dropbox.Api.Team.ListMemberAppsResult.Decoder, global::Dropbox.Api.Team.ListMemberAppsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListMemberAppsArg, ListMemberAppsResult, ListMemberAppsError>(listMemberAppsArg, "api", "/team/linked_apps/list_member_linked_apps", "team", global::Dropbox.Api.Team.ListMemberAppsArg.Encoder, global::Dropbox.Api.Team.ListMemberAppsResult.Decoder, global::Dropbox.Api.Team.ListMemberAppsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2501,16 +2573,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Note, this endpoint does not list any team-linked applications.</para>
         /// </summary>
         /// <param name="teamMemberId">The team member id.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMemberAppsError"/>.</exception>
-        public t.Task<ListMemberAppsResult> LinkedAppsListMemberLinkedAppsAsync(string teamMemberId)
+        public t.Task<ListMemberAppsResult> LinkedAppsListMemberLinkedAppsAsync(string teamMemberId,
+                                                                                tr.CancellationToken cancellationToken = default)
         {
             var listMemberAppsArg = new ListMemberAppsArg(teamMemberId);
 
-            return this.LinkedAppsListMemberLinkedAppsAsync(listMemberAppsArg);
+            return this.LinkedAppsListMemberLinkedAppsAsync(listMemberAppsArg, cancellationToken);
         }
 
         /// <summary>
@@ -2558,14 +2632,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Note, this endpoint does not list any team-linked applications.</para>
         /// </summary>
         /// <param name="listMembersAppsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMembersAppsError"/>.</exception>
-        public t.Task<ListMembersAppsResult> LinkedAppsListMembersLinkedAppsAsync(ListMembersAppsArg listMembersAppsArg)
+        public t.Task<ListMembersAppsResult> LinkedAppsListMembersLinkedAppsAsync(ListMembersAppsArg listMembersAppsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListMembersAppsArg, ListMembersAppsResult, ListMembersAppsError>(listMembersAppsArg, "api", "/team/linked_apps/list_members_linked_apps", "team", global::Dropbox.Api.Team.ListMembersAppsArg.Encoder, global::Dropbox.Api.Team.ListMembersAppsResult.Decoder, global::Dropbox.Api.Team.ListMembersAppsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListMembersAppsArg, ListMembersAppsResult, ListMembersAppsError>(listMembersAppsArg, "api", "/team/linked_apps/list_members_linked_apps", "team", global::Dropbox.Api.Team.ListMembersAppsArg.Encoder, global::Dropbox.Api.Team.ListMembersAppsResult.Decoder, global::Dropbox.Api.Team.ListMembersAppsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2594,16 +2669,18 @@ namespace Dropbox.Api.Team.Routes
         /// /> the cursor shouldn't be passed. Then, if the result of the call includes a
         /// cursor, the following requests should include the received cursors in order to
         /// receive the next sub list of the team applications.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListMembersAppsError"/>.</exception>
-        public t.Task<ListMembersAppsResult> LinkedAppsListMembersLinkedAppsAsync(string cursor = null)
+        public t.Task<ListMembersAppsResult> LinkedAppsListMembersLinkedAppsAsync(string cursor = null,
+                                                                                  tr.CancellationToken cancellationToken = default)
         {
             var listMembersAppsArg = new ListMembersAppsArg(cursor);
 
-            return this.LinkedAppsListMembersLinkedAppsAsync(listMembersAppsArg);
+            return this.LinkedAppsListMembersLinkedAppsAsync(listMembersAppsArg, cancellationToken);
         }
 
         /// <summary>
@@ -2655,15 +2732,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Note, this endpoint doesn't list any team-linked applications.</para>
         /// </summary>
         /// <param name="listTeamAppsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListTeamAppsError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use LinkedAppsListMembersLinkedAppsAsync instead.")]
-        public t.Task<ListTeamAppsResult> LinkedAppsListTeamLinkedAppsAsync(ListTeamAppsArg listTeamAppsArg)
+        public t.Task<ListTeamAppsResult> LinkedAppsListTeamLinkedAppsAsync(ListTeamAppsArg listTeamAppsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ListTeamAppsArg, ListTeamAppsResult, ListTeamAppsError>(listTeamAppsArg, "api", "/team/linked_apps/list_team_linked_apps", "team", global::Dropbox.Api.Team.ListTeamAppsArg.Encoder, global::Dropbox.Api.Team.ListTeamAppsResult.Decoder, global::Dropbox.Api.Team.ListTeamAppsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ListTeamAppsArg, ListTeamAppsResult, ListTeamAppsError>(listTeamAppsArg, "api", "/team/linked_apps/list_team_linked_apps", "team", global::Dropbox.Api.Team.ListTeamAppsArg.Encoder, global::Dropbox.Api.Team.ListTeamAppsResult.Decoder, global::Dropbox.Api.Team.ListTeamAppsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2693,17 +2771,19 @@ namespace Dropbox.Api.Team.Routes
         /// the cursor shouldn't be passed. Then, if the result of the call includes a cursor,
         /// the following requests should include the received cursors in order to receive the
         /// next sub list of the team applications.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ListTeamAppsError"/>.</exception>
         [sys.Obsolete("This function is deprecated, please use LinkedAppsListMembersLinkedAppsAsync instead.")]
-        public t.Task<ListTeamAppsResult> LinkedAppsListTeamLinkedAppsAsync(string cursor = null)
+        public t.Task<ListTeamAppsResult> LinkedAppsListTeamLinkedAppsAsync(string cursor = null,
+                                                                            tr.CancellationToken cancellationToken = default)
         {
             var listTeamAppsArg = new ListTeamAppsArg(cursor);
 
-            return this.LinkedAppsListTeamLinkedAppsAsync(listTeamAppsArg);
+            return this.LinkedAppsListTeamLinkedAppsAsync(listTeamAppsArg, cancellationToken);
         }
 
         /// <summary>
@@ -2756,13 +2836,14 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a linked application of the team member.</para>
         /// </summary>
         /// <param name="revokeLinkedApiAppArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeLinkedAppError"/>.</exception>
-        public t.Task LinkedAppsRevokeLinkedAppAsync(RevokeLinkedApiAppArg revokeLinkedApiAppArg)
+        public t.Task LinkedAppsRevokeLinkedAppAsync(RevokeLinkedApiAppArg revokeLinkedApiAppArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RevokeLinkedApiAppArg, enc.Empty, RevokeLinkedAppError>(revokeLinkedApiAppArg, "api", "/team/linked_apps/revoke_linked_app", "team", global::Dropbox.Api.Team.RevokeLinkedApiAppArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.RevokeLinkedAppError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RevokeLinkedApiAppArg, enc.Empty, RevokeLinkedAppError>(revokeLinkedApiAppArg, "api", "/team/linked_apps/revoke_linked_app", "team", global::Dropbox.Api.Team.RevokeLinkedApiAppArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.RevokeLinkedAppError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2789,19 +2870,21 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="teamMemberId">The unique id of the member owning the device.</param>
         /// <param name="keepAppFolder">This flag is not longer supported, the application
         /// dedicated folder (in case the application uses  one) will be kept.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeLinkedAppError"/>.</exception>
         public t.Task LinkedAppsRevokeLinkedAppAsync(string appId,
                                                      string teamMemberId,
-                                                     bool keepAppFolder = true)
+                                                     bool keepAppFolder = true,
+                                                     tr.CancellationToken cancellationToken = default)
         {
             var revokeLinkedApiAppArg = new RevokeLinkedApiAppArg(appId,
                                                                   teamMemberId,
                                                                   keepAppFolder);
 
-            return this.LinkedAppsRevokeLinkedAppAsync(revokeLinkedApiAppArg);
+            return this.LinkedAppsRevokeLinkedAppAsync(revokeLinkedApiAppArg, cancellationToken);
         }
 
         /// <summary>
@@ -2852,14 +2935,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a list of linked applications of the team members.</para>
         /// </summary>
         /// <param name="revokeLinkedApiAppBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeLinkedAppBatchError"/>.</exception>
-        public t.Task<RevokeLinkedAppBatchResult> LinkedAppsRevokeLinkedAppBatchAsync(RevokeLinkedApiAppBatchArg revokeLinkedApiAppBatchArg)
+        public t.Task<RevokeLinkedAppBatchResult> LinkedAppsRevokeLinkedAppBatchAsync(RevokeLinkedApiAppBatchArg revokeLinkedApiAppBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<RevokeLinkedApiAppBatchArg, RevokeLinkedAppBatchResult, RevokeLinkedAppBatchError>(revokeLinkedApiAppBatchArg, "api", "/team/linked_apps/revoke_linked_app_batch", "team", global::Dropbox.Api.Team.RevokeLinkedApiAppBatchArg.Encoder, global::Dropbox.Api.Team.RevokeLinkedAppBatchResult.Decoder, global::Dropbox.Api.Team.RevokeLinkedAppBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<RevokeLinkedApiAppBatchArg, RevokeLinkedAppBatchResult, RevokeLinkedAppBatchError>(revokeLinkedApiAppBatchArg, "api", "/team/linked_apps/revoke_linked_app_batch", "team", global::Dropbox.Api.Team.RevokeLinkedApiAppBatchArg.Encoder, global::Dropbox.Api.Team.RevokeLinkedAppBatchResult.Decoder, global::Dropbox.Api.Team.RevokeLinkedAppBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2883,16 +2967,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Revoke a list of linked applications of the team members.</para>
         /// </summary>
         /// <param name="revokeLinkedApp">The revoke linked app</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="RevokeLinkedAppBatchError"/>.</exception>
-        public t.Task<RevokeLinkedAppBatchResult> LinkedAppsRevokeLinkedAppBatchAsync(col.IEnumerable<RevokeLinkedApiAppArg> revokeLinkedApp)
+        public t.Task<RevokeLinkedAppBatchResult> LinkedAppsRevokeLinkedAppBatchAsync(col.IEnumerable<RevokeLinkedApiAppArg> revokeLinkedApp,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var revokeLinkedApiAppBatchArg = new RevokeLinkedApiAppBatchArg(revokeLinkedApp);
 
-            return this.LinkedAppsRevokeLinkedAppBatchAsync(revokeLinkedApiAppBatchArg);
+            return this.LinkedAppsRevokeLinkedAppBatchAsync(revokeLinkedApiAppBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -2939,14 +3025,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Add users to member space limits excluded users list.</para>
         /// </summary>
         /// <param name="excludedUsersUpdateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersUpdateError"/>.</exception>
-        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersAddAsync(ExcludedUsersUpdateArg excludedUsersUpdateArg)
+        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersAddAsync(ExcludedUsersUpdateArg excludedUsersUpdateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError>(excludedUsersUpdateArg, "api", "/team/member_space_limits/excluded_users/add", "team", global::Dropbox.Api.Team.ExcludedUsersUpdateArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersUpdateResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersUpdateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError>(excludedUsersUpdateArg, "api", "/team/member_space_limits/excluded_users/add", "team", global::Dropbox.Api.Team.ExcludedUsersUpdateArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersUpdateResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersUpdateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -2970,16 +3057,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Add users to member space limits excluded users list.</para>
         /// </summary>
         /// <param name="users">List of users to be added/removed.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersUpdateError"/>.</exception>
-        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersAddAsync(col.IEnumerable<UserSelectorArg> users = null)
+        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersAddAsync(col.IEnumerable<UserSelectorArg> users = null,
+                                                                                        tr.CancellationToken cancellationToken = default)
         {
             var excludedUsersUpdateArg = new ExcludedUsersUpdateArg(users);
 
-            return this.MemberSpaceLimitsExcludedUsersAddAsync(excludedUsersUpdateArg);
+            return this.MemberSpaceLimitsExcludedUsersAddAsync(excludedUsersUpdateArg, cancellationToken);
         }
 
         /// <summary>
@@ -3026,14 +3115,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>List member space limits excluded users.</para>
         /// </summary>
         /// <param name="excludedUsersListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersListError"/>.</exception>
-        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListAsync(ExcludedUsersListArg excludedUsersListArg)
+        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListAsync(ExcludedUsersListArg excludedUsersListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ExcludedUsersListArg, ExcludedUsersListResult, ExcludedUsersListError>(excludedUsersListArg, "api", "/team/member_space_limits/excluded_users/list", "team", global::Dropbox.Api.Team.ExcludedUsersListArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersListResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersListError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ExcludedUsersListArg, ExcludedUsersListResult, ExcludedUsersListError>(excludedUsersListArg, "api", "/team/member_space_limits/excluded_users/list", "team", global::Dropbox.Api.Team.ExcludedUsersListArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersListResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersListError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3057,16 +3147,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>List member space limits excluded users.</para>
         /// </summary>
         /// <param name="limit">Number of results to return per call.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersListError"/>.</exception>
-        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListAsync(uint limit = 1000)
+        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListAsync(uint limit = 1000,
+                                                                                       tr.CancellationToken cancellationToken = default)
         {
             var excludedUsersListArg = new ExcludedUsersListArg(limit);
 
-            return this.MemberSpaceLimitsExcludedUsersListAsync(excludedUsersListArg);
+            return this.MemberSpaceLimitsExcludedUsersListAsync(excludedUsersListArg, cancellationToken);
         }
 
         /// <summary>
@@ -3113,14 +3205,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Continue listing member space limits excluded users.</para>
         /// </summary>
         /// <param name="excludedUsersListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersListContinueError"/>.</exception>
-        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListContinueAsync(ExcludedUsersListContinueArg excludedUsersListContinueArg)
+        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListContinueAsync(ExcludedUsersListContinueArg excludedUsersListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ExcludedUsersListContinueArg, ExcludedUsersListResult, ExcludedUsersListContinueError>(excludedUsersListContinueArg, "api", "/team/member_space_limits/excluded_users/list/continue", "team", global::Dropbox.Api.Team.ExcludedUsersListContinueArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersListResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ExcludedUsersListContinueArg, ExcludedUsersListResult, ExcludedUsersListContinueError>(excludedUsersListContinueArg, "api", "/team/member_space_limits/excluded_users/list/continue", "team", global::Dropbox.Api.Team.ExcludedUsersListContinueArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersListResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3145,16 +3238,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// users.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersListContinueError"/>.</exception>
-        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListContinueAsync(string cursor)
+        public t.Task<ExcludedUsersListResult> MemberSpaceLimitsExcludedUsersListContinueAsync(string cursor,
+                                                                                               tr.CancellationToken cancellationToken = default)
         {
             var excludedUsersListContinueArg = new ExcludedUsersListContinueArg(cursor);
 
-            return this.MemberSpaceLimitsExcludedUsersListContinueAsync(excludedUsersListContinueArg);
+            return this.MemberSpaceLimitsExcludedUsersListContinueAsync(excludedUsersListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -3202,14 +3297,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Remove users from member space limits excluded users list.</para>
         /// </summary>
         /// <param name="excludedUsersUpdateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersUpdateError"/>.</exception>
-        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersRemoveAsync(ExcludedUsersUpdateArg excludedUsersUpdateArg)
+        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersRemoveAsync(ExcludedUsersUpdateArg excludedUsersUpdateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError>(excludedUsersUpdateArg, "api", "/team/member_space_limits/excluded_users/remove", "team", global::Dropbox.Api.Team.ExcludedUsersUpdateArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersUpdateResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersUpdateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError>(excludedUsersUpdateArg, "api", "/team/member_space_limits/excluded_users/remove", "team", global::Dropbox.Api.Team.ExcludedUsersUpdateArg.Encoder, global::Dropbox.Api.Team.ExcludedUsersUpdateResult.Decoder, global::Dropbox.Api.Team.ExcludedUsersUpdateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3233,16 +3329,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Remove users from member space limits excluded users list.</para>
         /// </summary>
         /// <param name="users">List of users to be added/removed.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="ExcludedUsersUpdateError"/>.</exception>
-        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersRemoveAsync(col.IEnumerable<UserSelectorArg> users = null)
+        public t.Task<ExcludedUsersUpdateResult> MemberSpaceLimitsExcludedUsersRemoveAsync(col.IEnumerable<UserSelectorArg> users = null,
+                                                                                           tr.CancellationToken cancellationToken = default)
         {
             var excludedUsersUpdateArg = new ExcludedUsersUpdateArg(users);
 
-            return this.MemberSpaceLimitsExcludedUsersRemoveAsync(excludedUsersUpdateArg);
+            return this.MemberSpaceLimitsExcludedUsersRemoveAsync(excludedUsersUpdateArg, cancellationToken);
         }
 
         /// <summary>
@@ -3290,14 +3388,15 @@ namespace Dropbox.Api.Team.Routes
         /// maximum of 1000 members can be specified in a single call.</para>
         /// </summary>
         /// <param name="customQuotaUsersArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CustomQuotaError"/>.</exception>
-        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsGetCustomQuotaAsync(CustomQuotaUsersArg customQuotaUsersArg)
+        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsGetCustomQuotaAsync(CustomQuotaUsersArg customQuotaUsersArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CustomQuotaUsersArg, col.List<CustomQuotaResult>, CustomQuotaError>(customQuotaUsersArg, "api", "/team/member_space_limits/get_custom_quota", "team", global::Dropbox.Api.Team.CustomQuotaUsersArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.CustomQuotaResult.Decoder), global::Dropbox.Api.Team.CustomQuotaError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CustomQuotaUsersArg, col.List<CustomQuotaResult>, CustomQuotaError>(customQuotaUsersArg, "api", "/team/member_space_limits/get_custom_quota", "team", global::Dropbox.Api.Team.CustomQuotaUsersArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.CustomQuotaResult.Decoder), global::Dropbox.Api.Team.CustomQuotaError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3322,16 +3421,18 @@ namespace Dropbox.Api.Team.Routes
         /// maximum of 1000 members can be specified in a single call.</para>
         /// </summary>
         /// <param name="users">List of users.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CustomQuotaError"/>.</exception>
-        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsGetCustomQuotaAsync(col.IEnumerable<UserSelectorArg> users)
+        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsGetCustomQuotaAsync(col.IEnumerable<UserSelectorArg> users,
+                                                                                        tr.CancellationToken cancellationToken = default)
         {
             var customQuotaUsersArg = new CustomQuotaUsersArg(users);
 
-            return this.MemberSpaceLimitsGetCustomQuotaAsync(customQuotaUsersArg);
+            return this.MemberSpaceLimitsGetCustomQuotaAsync(customQuotaUsersArg, cancellationToken);
         }
 
         /// <summary>
@@ -3379,14 +3480,15 @@ namespace Dropbox.Api.Team.Routes
         /// single call.</para>
         /// </summary>
         /// <param name="customQuotaUsersArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CustomQuotaError"/>.</exception>
-        public t.Task<col.List<RemoveCustomQuotaResult>> MemberSpaceLimitsRemoveCustomQuotaAsync(CustomQuotaUsersArg customQuotaUsersArg)
+        public t.Task<col.List<RemoveCustomQuotaResult>> MemberSpaceLimitsRemoveCustomQuotaAsync(CustomQuotaUsersArg customQuotaUsersArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<CustomQuotaUsersArg, col.List<RemoveCustomQuotaResult>, CustomQuotaError>(customQuotaUsersArg, "api", "/team/member_space_limits/remove_custom_quota", "team", global::Dropbox.Api.Team.CustomQuotaUsersArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.RemoveCustomQuotaResult.Decoder), global::Dropbox.Api.Team.CustomQuotaError.Decoder);
+            return this.Transport.SendRpcRequestAsync<CustomQuotaUsersArg, col.List<RemoveCustomQuotaResult>, CustomQuotaError>(customQuotaUsersArg, "api", "/team/member_space_limits/remove_custom_quota", "team", global::Dropbox.Api.Team.CustomQuotaUsersArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.RemoveCustomQuotaResult.Decoder), global::Dropbox.Api.Team.CustomQuotaError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3411,16 +3513,18 @@ namespace Dropbox.Api.Team.Routes
         /// single call.</para>
         /// </summary>
         /// <param name="users">List of users.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="CustomQuotaError"/>.</exception>
-        public t.Task<col.List<RemoveCustomQuotaResult>> MemberSpaceLimitsRemoveCustomQuotaAsync(col.IEnumerable<UserSelectorArg> users)
+        public t.Task<col.List<RemoveCustomQuotaResult>> MemberSpaceLimitsRemoveCustomQuotaAsync(col.IEnumerable<UserSelectorArg> users,
+                                                                                                 tr.CancellationToken cancellationToken = default)
         {
             var customQuotaUsersArg = new CustomQuotaUsersArg(users);
 
-            return this.MemberSpaceLimitsRemoveCustomQuotaAsync(customQuotaUsersArg);
+            return this.MemberSpaceLimitsRemoveCustomQuotaAsync(customQuotaUsersArg, cancellationToken);
         }
 
         /// <summary>
@@ -3468,14 +3572,15 @@ namespace Dropbox.Api.Team.Routes
         /// 1000 members can be specified in a single call.</para>
         /// </summary>
         /// <param name="setCustomQuotaArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetCustomQuotaError"/>.</exception>
-        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsSetCustomQuotaAsync(SetCustomQuotaArg setCustomQuotaArg)
+        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsSetCustomQuotaAsync(SetCustomQuotaArg setCustomQuotaArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<SetCustomQuotaArg, col.List<CustomQuotaResult>, SetCustomQuotaError>(setCustomQuotaArg, "api", "/team/member_space_limits/set_custom_quota", "team", global::Dropbox.Api.Team.SetCustomQuotaArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.CustomQuotaResult.Decoder), global::Dropbox.Api.Team.SetCustomQuotaError.Decoder);
+            return this.Transport.SendRpcRequestAsync<SetCustomQuotaArg, col.List<CustomQuotaResult>, SetCustomQuotaError>(setCustomQuotaArg, "api", "/team/member_space_limits/set_custom_quota", "team", global::Dropbox.Api.Team.SetCustomQuotaArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.CustomQuotaResult.Decoder), global::Dropbox.Api.Team.SetCustomQuotaError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3500,16 +3605,18 @@ namespace Dropbox.Api.Team.Routes
         /// 1000 members can be specified in a single call.</para>
         /// </summary>
         /// <param name="usersAndQuotas">List of users and their custom quotas.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="SetCustomQuotaError"/>.</exception>
-        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsSetCustomQuotaAsync(col.IEnumerable<UserCustomQuotaArg> usersAndQuotas)
+        public t.Task<col.List<CustomQuotaResult>> MemberSpaceLimitsSetCustomQuotaAsync(col.IEnumerable<UserCustomQuotaArg> usersAndQuotas,
+                                                                                        tr.CancellationToken cancellationToken = default)
         {
             var setCustomQuotaArg = new SetCustomQuotaArg(usersAndQuotas);
 
-            return this.MemberSpaceLimitsSetCustomQuotaAsync(setCustomQuotaArg);
+            return this.MemberSpaceLimitsSetCustomQuotaAsync(setCustomQuotaArg, cancellationToken);
         }
 
         /// <summary>
@@ -3568,11 +3675,12 @@ namespace Dropbox.Api.Team.Routes
         /// actions taken on the user before they become 'active'.</para>
         /// </summary>
         /// <param name="membersAddArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<MembersAddLaunch> MembersAddAsync(MembersAddArg membersAddArg)
+        public t.Task<MembersAddLaunch> MembersAddAsync(MembersAddArg membersAddArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersAddArg, MembersAddLaunch, enc.Empty>(membersAddArg, "api", "/team/members/add", "team", global::Dropbox.Api.Team.MembersAddArg.Encoder, global::Dropbox.Api.Team.MembersAddLaunch.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<MembersAddArg, MembersAddLaunch, enc.Empty>(membersAddArg, "api", "/team/members/add", "team", global::Dropbox.Api.Team.MembersAddArg.Encoder, global::Dropbox.Api.Team.MembersAddLaunch.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -3608,15 +3716,17 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="newMembers">Details of new members to be added to the team.</param>
         /// <param name="forceAsync">Whether to force the add to happen asynchronously.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         public t.Task<MembersAddLaunch> MembersAddAsync(col.IEnumerable<MemberAddArg> newMembers,
-                                                        bool forceAsync = false)
+                                                        bool forceAsync = false,
+                                                        tr.CancellationToken cancellationToken = default)
         {
             var membersAddArg = new MembersAddArg(newMembers,
                                                   forceAsync);
 
-            return this.MembersAddAsync(membersAddArg);
+            return this.MembersAddAsync(membersAddArg, cancellationToken);
         }
 
         /// <summary>
@@ -3665,14 +3775,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<MembersAddJobStatus> MembersAddJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<MembersAddJobStatus> MembersAddJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, MembersAddJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/add/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Team.MembersAddJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, MembersAddJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/add/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Team.MembersAddJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3699,16 +3810,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<MembersAddJobStatus> MembersAddJobStatusGetAsync(string asyncJobId)
+        public t.Task<MembersAddJobStatus> MembersAddJobStatusGetAsync(string asyncJobId,
+                                                                       tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.MembersAddJobStatusGetAsync(pollArg);
+            return this.MembersAddJobStatusGetAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -3756,14 +3869,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="membersDeleteProfilePhotoArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersDeleteProfilePhotoError"/>.</exception>
-        public t.Task<TeamMemberInfo> MembersDeleteProfilePhotoAsync(MembersDeleteProfilePhotoArg membersDeleteProfilePhotoArg)
+        public t.Task<TeamMemberInfo> MembersDeleteProfilePhotoAsync(MembersDeleteProfilePhotoArg membersDeleteProfilePhotoArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersDeleteProfilePhotoArg, TeamMemberInfo, MembersDeleteProfilePhotoError>(membersDeleteProfilePhotoArg, "api", "/team/members/delete_profile_photo", "team", global::Dropbox.Api.Team.MembersDeleteProfilePhotoArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersDeleteProfilePhotoError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersDeleteProfilePhotoArg, TeamMemberInfo, MembersDeleteProfilePhotoError>(membersDeleteProfilePhotoArg, "api", "/team/members/delete_profile_photo", "team", global::Dropbox.Api.Team.MembersDeleteProfilePhotoArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersDeleteProfilePhotoError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3788,16 +3902,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="user">Identity of the user whose profile photo will be
         /// deleted.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersDeleteProfilePhotoError"/>.</exception>
-        public t.Task<TeamMemberInfo> MembersDeleteProfilePhotoAsync(UserSelectorArg user)
+        public t.Task<TeamMemberInfo> MembersDeleteProfilePhotoAsync(UserSelectorArg user,
+                                                                     tr.CancellationToken cancellationToken = default)
         {
             var membersDeleteProfilePhotoArg = new MembersDeleteProfilePhotoArg(user);
 
-            return this.MembersDeleteProfilePhotoAsync(membersDeleteProfilePhotoArg);
+            return this.MembersDeleteProfilePhotoAsync(membersDeleteProfilePhotoArg, cancellationToken);
         }
 
         /// <summary>
@@ -3848,14 +3964,15 @@ namespace Dropbox.Api.Team.Routes
         /// cannot be matched to a valid team member.</para>
         /// </summary>
         /// <param name="membersGetInfoArgs">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersGetInfoError"/>.</exception>
-        public t.Task<col.List<MembersGetInfoItem>> MembersGetInfoAsync(MembersGetInfoArgs membersGetInfoArgs)
+        public t.Task<col.List<MembersGetInfoItem>> MembersGetInfoAsync(MembersGetInfoArgs membersGetInfoArgs, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersGetInfoArgs, col.List<MembersGetInfoItem>, MembersGetInfoError>(membersGetInfoArgs, "api", "/team/members/get_info", "team", global::Dropbox.Api.Team.MembersGetInfoArgs.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.MembersGetInfoItem.Decoder), global::Dropbox.Api.Team.MembersGetInfoError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersGetInfoArgs, col.List<MembersGetInfoItem>, MembersGetInfoError>(membersGetInfoArgs, "api", "/team/members/get_info", "team", global::Dropbox.Api.Team.MembersGetInfoArgs.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.MembersGetInfoItem.Decoder), global::Dropbox.Api.Team.MembersGetInfoError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3882,16 +3999,18 @@ namespace Dropbox.Api.Team.Routes
         /// cannot be matched to a valid team member.</para>
         /// </summary>
         /// <param name="members">List of team members.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersGetInfoError"/>.</exception>
-        public t.Task<col.List<MembersGetInfoItem>> MembersGetInfoAsync(col.IEnumerable<UserSelectorArg> members)
+        public t.Task<col.List<MembersGetInfoItem>> MembersGetInfoAsync(col.IEnumerable<UserSelectorArg> members,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var membersGetInfoArgs = new MembersGetInfoArgs(members);
 
-            return this.MembersGetInfoAsync(membersGetInfoArgs);
+            return this.MembersGetInfoAsync(membersGetInfoArgs, cancellationToken);
         }
 
         /// <summary>
@@ -3938,14 +4057,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team information.</para>
         /// </summary>
         /// <param name="membersListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersListError"/>.</exception>
-        public t.Task<MembersListResult> MembersListAsync(MembersListArg membersListArg)
+        public t.Task<MembersListResult> MembersListAsync(MembersListArg membersListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersListArg, MembersListResult, MembersListError>(membersListArg, "api", "/team/members/list", "team", global::Dropbox.Api.Team.MembersListArg.Encoder, global::Dropbox.Api.Team.MembersListResult.Decoder, global::Dropbox.Api.Team.MembersListError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersListArg, MembersListResult, MembersListError>(membersListArg, "api", "/team/members/list", "team", global::Dropbox.Api.Team.MembersListArg.Encoder, global::Dropbox.Api.Team.MembersListResult.Decoder, global::Dropbox.Api.Team.MembersListError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -3970,18 +4090,20 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="limit">Number of results to return per call.</param>
         /// <param name="includeRemoved">Whether to return removed members.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersListError"/>.</exception>
         public t.Task<MembersListResult> MembersListAsync(uint limit = 1000,
-                                                          bool includeRemoved = false)
+                                                          bool includeRemoved = false,
+                                                          tr.CancellationToken cancellationToken = default)
         {
             var membersListArg = new MembersListArg(limit,
                                                     includeRemoved);
 
-            return this.MembersListAsync(membersListArg);
+            return this.MembersListAsync(membersListArg, cancellationToken);
         }
 
         /// <summary>
@@ -4033,14 +4155,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team information.</para>
         /// </summary>
         /// <param name="membersListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersListContinueError"/>.</exception>
-        public t.Task<MembersListResult> MembersListContinueAsync(MembersListContinueArg membersListContinueArg)
+        public t.Task<MembersListResult> MembersListContinueAsync(MembersListContinueArg membersListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersListContinueArg, MembersListResult, MembersListContinueError>(membersListContinueArg, "api", "/team/members/list/continue", "team", global::Dropbox.Api.Team.MembersListContinueArg.Encoder, global::Dropbox.Api.Team.MembersListResult.Decoder, global::Dropbox.Api.Team.MembersListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersListContinueArg, MembersListResult, MembersListContinueError>(membersListContinueArg, "api", "/team/members/list/continue", "team", global::Dropbox.Api.Team.MembersListContinueArg.Encoder, global::Dropbox.Api.Team.MembersListResult.Decoder, global::Dropbox.Api.Team.MembersListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4067,16 +4190,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// members.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersListContinueError"/>.</exception>
-        public t.Task<MembersListResult> MembersListContinueAsync(string cursor)
+        public t.Task<MembersListResult> MembersListContinueAsync(string cursor,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var membersListContinueArg = new MembersListContinueArg(cursor);
 
-            return this.MembersListContinueAsync(membersListContinueArg);
+            return this.MembersListContinueAsync(membersListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -4128,14 +4253,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="membersDataTransferArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersTransferFormerMembersFilesError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> MembersMoveFormerMemberFilesAsync(MembersDataTransferArg membersDataTransferArg)
+        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> MembersMoveFormerMemberFilesAsync(MembersDataTransferArg membersDataTransferArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersDataTransferArg, global::Dropbox.Api.Async.LaunchEmptyResult, MembersTransferFormerMembersFilesError>(membersDataTransferArg, "api", "/team/members/move_former_member_files", "team", global::Dropbox.Api.Team.MembersDataTransferArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.MembersTransferFormerMembersFilesError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersDataTransferArg, global::Dropbox.Api.Async.LaunchEmptyResult, MembersTransferFormerMembersFilesError>(membersDataTransferArg, "api", "/team/members/move_former_member_files", "team", global::Dropbox.Api.Team.MembersDataTransferArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.MembersTransferFormerMembersFilesError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4169,6 +4295,7 @@ namespace Dropbox.Api.Team.Routes
         /// transferred to this user.</param>
         /// <param name="transferAdminId">Errors during the transfer process will be sent via
         /// email to this user.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4176,13 +4303,14 @@ namespace Dropbox.Api.Team.Routes
         /// cref="MembersTransferFormerMembersFilesError"/>.</exception>
         public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> MembersMoveFormerMemberFilesAsync(UserSelectorArg user,
                                                                                                      UserSelectorArg transferDestId,
-                                                                                                     UserSelectorArg transferAdminId)
+                                                                                                     UserSelectorArg transferAdminId,
+                                                                                                     tr.CancellationToken cancellationToken = default)
         {
             var membersDataTransferArg = new MembersDataTransferArg(user,
                                                                     transferDestId,
                                                                     transferAdminId);
 
-            return this.MembersMoveFormerMemberFilesAsync(membersDataTransferArg);
+            return this.MembersMoveFormerMemberFilesAsync(membersDataTransferArg, cancellationToken);
         }
 
         /// <summary>
@@ -4241,14 +4369,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersMoveFormerMemberFilesJobStatusCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersMoveFormerMemberFilesJobStatusCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/move_former_member_files/job_status/check", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/move_former_member_files/job_status/check", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4276,16 +4405,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersMoveFormerMemberFilesJobStatusCheckAsync(string asyncJobId)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersMoveFormerMemberFilesJobStatusCheckAsync(string asyncJobId,
+                                                                                                                 tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.MembersMoveFormerMemberFilesJobStatusCheckAsync(pollArg);
+            return this.MembersMoveFormerMemberFilesJobStatusCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -4336,13 +4467,14 @@ namespace Dropbox.Api.Team.Routes
         /// identify the user account.</para>
         /// </summary>
         /// <param name="membersRecoverArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersRecoverError"/>.</exception>
-        public t.Task MembersRecoverAsync(MembersRecoverArg membersRecoverArg)
+        public t.Task MembersRecoverAsync(MembersRecoverArg membersRecoverArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersRecoverArg, enc.Empty, MembersRecoverError>(membersRecoverArg, "api", "/team/members/recover", "team", global::Dropbox.Api.Team.MembersRecoverArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersRecoverError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersRecoverArg, enc.Empty, MembersRecoverError>(membersRecoverArg, "api", "/team/members/recover", "team", global::Dropbox.Api.Team.MembersRecoverArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersRecoverError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4368,15 +4500,17 @@ namespace Dropbox.Api.Team.Routes
         /// identify the user account.</para>
         /// </summary>
         /// <param name="user">Identity of user to recover.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersRecoverError"/>.</exception>
-        public t.Task MembersRecoverAsync(UserSelectorArg user)
+        public t.Task MembersRecoverAsync(UserSelectorArg user,
+                                          tr.CancellationToken cancellationToken = default)
         {
             var membersRecoverArg = new MembersRecoverArg(user);
 
-            return this.MembersRecoverAsync(membersRecoverArg);
+            return this.MembersRecoverAsync(membersRecoverArg, cancellationToken);
         }
 
         /// <summary>
@@ -4436,14 +4570,15 @@ namespace Dropbox.Api.Team.Routes
         /// />.</para>
         /// </summary>
         /// <param name="membersRemoveArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersRemoveError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> MembersRemoveAsync(MembersRemoveArg membersRemoveArg)
+        public t.Task<global::Dropbox.Api.Async.LaunchEmptyResult> MembersRemoveAsync(MembersRemoveArg membersRemoveArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersRemoveArg, global::Dropbox.Api.Async.LaunchEmptyResult, MembersRemoveError>(membersRemoveArg, "api", "/team/members/remove", "team", global::Dropbox.Api.Team.MembersRemoveArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.MembersRemoveError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersRemoveArg, global::Dropbox.Api.Async.LaunchEmptyResult, MembersRemoveError>(membersRemoveArg, "api", "/team/members/remove", "team", global::Dropbox.Api.Team.MembersRemoveArg.Encoder, global::Dropbox.Api.Async.LaunchEmptyResult.Decoder, global::Dropbox.Api.Team.MembersRemoveError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4502,6 +4637,7 @@ namespace Dropbox.Api.Team.Routes
         /// sharing relationships, the arguments <paramref name="wipeData" /> should be set to
         /// <c>false</c> and <paramref name="keepAccount" /> should be set to
         /// <c>true</c>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -4512,7 +4648,8 @@ namespace Dropbox.Api.Team.Routes
                                                                                       UserSelectorArg transferDestId = null,
                                                                                       UserSelectorArg transferAdminId = null,
                                                                                       bool keepAccount = false,
-                                                                                      bool retainTeamShares = false)
+                                                                                      bool retainTeamShares = false,
+                                                                                      tr.CancellationToken cancellationToken = default)
         {
             var membersRemoveArg = new MembersRemoveArg(user,
                                                         wipeData,
@@ -4521,7 +4658,7 @@ namespace Dropbox.Api.Team.Routes
                                                         keepAccount,
                                                         retainTeamShares);
 
-            return this.MembersRemoveAsync(membersRemoveArg);
+            return this.MembersRemoveAsync(membersRemoveArg, cancellationToken);
         }
 
         /// <summary>
@@ -4599,14 +4736,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersRemoveJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersRemoveJobStatusGetAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/remove/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, global::Dropbox.Api.Async.PollEmptyResult, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/members/remove/job_status/get", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Async.PollEmptyResult.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4634,16 +4772,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersRemoveJobStatusGetAsync(string asyncJobId)
+        public t.Task<global::Dropbox.Api.Async.PollEmptyResult> MembersRemoveJobStatusGetAsync(string asyncJobId,
+                                                                                                tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.MembersRemoveJobStatusGetAsync(pollArg);
+            return this.MembersRemoveJobStatusGetAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -4694,14 +4834,15 @@ namespace Dropbox.Api.Team.Routes
         /// email address not on a verified domain a verification email will be sent.</para>
         /// </summary>
         /// <param name="addSecondaryEmailsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddSecondaryEmailsError"/>.</exception>
-        public t.Task<AddSecondaryEmailsResult> MembersSecondaryEmailsAddAsync(AddSecondaryEmailsArg addSecondaryEmailsArg)
+        public t.Task<AddSecondaryEmailsResult> MembersSecondaryEmailsAddAsync(AddSecondaryEmailsArg addSecondaryEmailsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<AddSecondaryEmailsArg, AddSecondaryEmailsResult, AddSecondaryEmailsError>(addSecondaryEmailsArg, "api", "/team/members/secondary_emails/add", "team", global::Dropbox.Api.Team.AddSecondaryEmailsArg.Encoder, global::Dropbox.Api.Team.AddSecondaryEmailsResult.Decoder, global::Dropbox.Api.Team.AddSecondaryEmailsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<AddSecondaryEmailsArg, AddSecondaryEmailsResult, AddSecondaryEmailsError>(addSecondaryEmailsArg, "api", "/team/members/secondary_emails/add", "team", global::Dropbox.Api.Team.AddSecondaryEmailsArg.Encoder, global::Dropbox.Api.Team.AddSecondaryEmailsResult.Decoder, global::Dropbox.Api.Team.AddSecondaryEmailsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -4727,16 +4868,18 @@ namespace Dropbox.Api.Team.Routes
         /// email address not on a verified domain a verification email will be sent.</para>
         /// </summary>
         /// <param name="newSecondaryEmails">List of users and secondary emails to add.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="AddSecondaryEmailsError"/>.</exception>
-        public t.Task<AddSecondaryEmailsResult> MembersSecondaryEmailsAddAsync(col.IEnumerable<UserSecondaryEmailsArg> newSecondaryEmails)
+        public t.Task<AddSecondaryEmailsResult> MembersSecondaryEmailsAddAsync(col.IEnumerable<UserSecondaryEmailsArg> newSecondaryEmails,
+                                                                               tr.CancellationToken cancellationToken = default)
         {
             var addSecondaryEmailsArg = new AddSecondaryEmailsArg(newSecondaryEmails);
 
-            return this.MembersSecondaryEmailsAddAsync(addSecondaryEmailsArg);
+            return this.MembersSecondaryEmailsAddAsync(addSecondaryEmailsArg, cancellationToken);
         }
 
         /// <summary>
@@ -4785,11 +4928,12 @@ namespace Dropbox.Api.Team.Routes
         /// secondary email and their primary email.</para>
         /// </summary>
         /// <param name="deleteSecondaryEmailsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<DeleteSecondaryEmailsResult> MembersSecondaryEmailsDeleteAsync(DeleteSecondaryEmailsArg deleteSecondaryEmailsArg)
+        public t.Task<DeleteSecondaryEmailsResult> MembersSecondaryEmailsDeleteAsync(DeleteSecondaryEmailsArg deleteSecondaryEmailsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DeleteSecondaryEmailsArg, DeleteSecondaryEmailsResult, enc.Empty>(deleteSecondaryEmailsArg, "api", "/team/members/secondary_emails/delete", "team", global::Dropbox.Api.Team.DeleteSecondaryEmailsArg.Encoder, global::Dropbox.Api.Team.DeleteSecondaryEmailsResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<DeleteSecondaryEmailsArg, DeleteSecondaryEmailsResult, enc.Empty>(deleteSecondaryEmailsArg, "api", "/team/members/secondary_emails/delete", "team", global::Dropbox.Api.Team.DeleteSecondaryEmailsArg.Encoder, global::Dropbox.Api.Team.DeleteSecondaryEmailsResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -4817,13 +4961,15 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="emailsToDelete">List of users and their secondary emails to
         /// delete.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<DeleteSecondaryEmailsResult> MembersSecondaryEmailsDeleteAsync(col.IEnumerable<UserSecondaryEmailsArg> emailsToDelete)
+        public t.Task<DeleteSecondaryEmailsResult> MembersSecondaryEmailsDeleteAsync(col.IEnumerable<UserSecondaryEmailsArg> emailsToDelete,
+                                                                                     tr.CancellationToken cancellationToken = default)
         {
             var deleteSecondaryEmailsArg = new DeleteSecondaryEmailsArg(emailsToDelete);
 
-            return this.MembersSecondaryEmailsDeleteAsync(deleteSecondaryEmailsArg);
+            return this.MembersSecondaryEmailsDeleteAsync(deleteSecondaryEmailsArg, cancellationToken);
         }
 
         /// <summary>
@@ -4869,11 +5015,12 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="resendVerificationEmailArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<ResendVerificationEmailResult> MembersSecondaryEmailsResendVerificationEmailsAsync(ResendVerificationEmailArg resendVerificationEmailArg)
+        public t.Task<ResendVerificationEmailResult> MembersSecondaryEmailsResendVerificationEmailsAsync(ResendVerificationEmailArg resendVerificationEmailArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<ResendVerificationEmailArg, ResendVerificationEmailResult, enc.Empty>(resendVerificationEmailArg, "api", "/team/members/secondary_emails/resend_verification_emails", "team", global::Dropbox.Api.Team.ResendVerificationEmailArg.Encoder, global::Dropbox.Api.Team.ResendVerificationEmailResult.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<ResendVerificationEmailArg, ResendVerificationEmailResult, enc.Empty>(resendVerificationEmailArg, "api", "/team/members/secondary_emails/resend_verification_emails", "team", global::Dropbox.Api.Team.ResendVerificationEmailArg.Encoder, global::Dropbox.Api.Team.ResendVerificationEmailResult.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -4899,13 +5046,15 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="emailsToResend">List of users and secondary emails to resend
         /// verification emails to.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<ResendVerificationEmailResult> MembersSecondaryEmailsResendVerificationEmailsAsync(col.IEnumerable<UserSecondaryEmailsArg> emailsToResend)
+        public t.Task<ResendVerificationEmailResult> MembersSecondaryEmailsResendVerificationEmailsAsync(col.IEnumerable<UserSecondaryEmailsArg> emailsToResend,
+                                                                                                         tr.CancellationToken cancellationToken = default)
         {
             var resendVerificationEmailArg = new ResendVerificationEmailArg(emailsToResend);
 
-            return this.MembersSecondaryEmailsResendVerificationEmailsAsync(resendVerificationEmailArg);
+            return this.MembersSecondaryEmailsResendVerificationEmailsAsync(resendVerificationEmailArg, cancellationToken);
         }
 
         /// <summary>
@@ -4954,13 +5103,14 @@ namespace Dropbox.Api.Team.Routes
         /// <para>No-op if team member is not pending.</para>
         /// </summary>
         /// <param name="userSelectorArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSendWelcomeError"/>.</exception>
-        public t.Task MembersSendWelcomeEmailAsync(UserSelectorArg userSelectorArg)
+        public t.Task MembersSendWelcomeEmailAsync(UserSelectorArg userSelectorArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UserSelectorArg, enc.Empty, MembersSendWelcomeError>(userSelectorArg, "api", "/team/members/send_welcome_email", "team", global::Dropbox.Api.Team.UserSelectorArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersSendWelcomeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UserSelectorArg, enc.Empty, MembersSendWelcomeError>(userSelectorArg, "api", "/team/members/send_welcome_email", "team", global::Dropbox.Api.Team.UserSelectorArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersSendWelcomeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5002,14 +5152,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="membersSetPermissionsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSetPermissionsError"/>.</exception>
-        public t.Task<MembersSetPermissionsResult> MembersSetAdminPermissionsAsync(MembersSetPermissionsArg membersSetPermissionsArg)
+        public t.Task<MembersSetPermissionsResult> MembersSetAdminPermissionsAsync(MembersSetPermissionsArg membersSetPermissionsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersSetPermissionsArg, MembersSetPermissionsResult, MembersSetPermissionsError>(membersSetPermissionsArg, "api", "/team/members/set_admin_permissions", "team", global::Dropbox.Api.Team.MembersSetPermissionsArg.Encoder, global::Dropbox.Api.Team.MembersSetPermissionsResult.Decoder, global::Dropbox.Api.Team.MembersSetPermissionsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersSetPermissionsArg, MembersSetPermissionsResult, MembersSetPermissionsError>(membersSetPermissionsArg, "api", "/team/members/set_admin_permissions", "team", global::Dropbox.Api.Team.MembersSetPermissionsArg.Encoder, global::Dropbox.Api.Team.MembersSetPermissionsResult.Decoder, global::Dropbox.Api.Team.MembersSetPermissionsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5035,18 +5186,20 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="user">Identity of user whose role will be set.</param>
         /// <param name="newRole">The new role of the member.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSetPermissionsError"/>.</exception>
         public t.Task<MembersSetPermissionsResult> MembersSetAdminPermissionsAsync(UserSelectorArg user,
-                                                                                   AdminTier newRole)
+                                                                                   AdminTier newRole,
+                                                                                   tr.CancellationToken cancellationToken = default)
         {
             var membersSetPermissionsArg = new MembersSetPermissionsArg(user,
                                                                         newRole);
 
-            return this.MembersSetAdminPermissionsAsync(membersSetPermissionsArg);
+            return this.MembersSetAdminPermissionsAsync(membersSetPermissionsArg, cancellationToken);
         }
 
         /// <summary>
@@ -5097,14 +5250,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="membersSetProfileArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSetProfileError"/>.</exception>
-        public t.Task<TeamMemberInfo> MembersSetProfileAsync(MembersSetProfileArg membersSetProfileArg)
+        public t.Task<TeamMemberInfo> MembersSetProfileAsync(MembersSetProfileArg membersSetProfileArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersSetProfileArg, TeamMemberInfo, MembersSetProfileError>(membersSetProfileArg, "api", "/team/members/set_profile", "team", global::Dropbox.Api.Team.MembersSetProfileArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersSetProfileError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersSetProfileArg, TeamMemberInfo, MembersSetProfileError>(membersSetProfileArg, "api", "/team/members/set_profile", "team", global::Dropbox.Api.Team.MembersSetProfileArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersSetProfileError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5136,6 +5290,7 @@ namespace Dropbox.Api.Team.Routes
         /// using persistent ID SAML configuration.</param>
         /// <param name="newIsDirectoryRestricted">New value for whether the user is a
         /// directory restricted user.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -5147,7 +5302,8 @@ namespace Dropbox.Api.Team.Routes
                                                              string newGivenName = null,
                                                              string newSurname = null,
                                                              string newPersistentId = null,
-                                                             bool? newIsDirectoryRestricted = null)
+                                                             bool? newIsDirectoryRestricted = null,
+                                                             tr.CancellationToken cancellationToken = default)
         {
             var membersSetProfileArg = new MembersSetProfileArg(user,
                                                                 newEmail,
@@ -5157,7 +5313,7 @@ namespace Dropbox.Api.Team.Routes
                                                                 newPersistentId,
                                                                 newIsDirectoryRestricted);
 
-            return this.MembersSetProfileAsync(membersSetProfileArg);
+            return this.MembersSetProfileAsync(membersSetProfileArg, cancellationToken);
         }
 
         /// <summary>
@@ -5224,14 +5380,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member management.</para>
         /// </summary>
         /// <param name="membersSetProfilePhotoArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSetProfilePhotoError"/>.</exception>
-        public t.Task<TeamMemberInfo> MembersSetProfilePhotoAsync(MembersSetProfilePhotoArg membersSetProfilePhotoArg)
+        public t.Task<TeamMemberInfo> MembersSetProfilePhotoAsync(MembersSetProfilePhotoArg membersSetProfilePhotoArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersSetProfilePhotoArg, TeamMemberInfo, MembersSetProfilePhotoError>(membersSetProfilePhotoArg, "api", "/team/members/set_profile_photo", "team", global::Dropbox.Api.Team.MembersSetProfilePhotoArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersSetProfilePhotoError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersSetProfilePhotoArg, TeamMemberInfo, MembersSetProfilePhotoError>(membersSetProfilePhotoArg, "api", "/team/members/set_profile_photo", "team", global::Dropbox.Api.Team.MembersSetProfilePhotoArg.Encoder, global::Dropbox.Api.Team.TeamMemberInfo.Decoder, global::Dropbox.Api.Team.MembersSetProfilePhotoError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5256,18 +5413,20 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="user">Identity of the user whose profile photo will be set.</param>
         /// <param name="photo">Image to set as the member's new profile photo.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSetProfilePhotoError"/>.</exception>
         public t.Task<TeamMemberInfo> MembersSetProfilePhotoAsync(UserSelectorArg user,
-                                                                  global::Dropbox.Api.Account.PhotoSourceArg photo)
+                                                                  global::Dropbox.Api.Account.PhotoSourceArg photo,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var membersSetProfilePhotoArg = new MembersSetProfilePhotoArg(user,
                                                                           photo);
 
-            return this.MembersSetProfilePhotoAsync(membersSetProfilePhotoArg);
+            return this.MembersSetProfilePhotoAsync(membersSetProfilePhotoArg, cancellationToken);
         }
 
         /// <summary>
@@ -5319,13 +5478,14 @@ namespace Dropbox.Api.Team.Routes
         /// identify the user account.</para>
         /// </summary>
         /// <param name="membersDeactivateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSuspendError"/>.</exception>
-        public t.Task MembersSuspendAsync(MembersDeactivateArg membersDeactivateArg)
+        public t.Task MembersSuspendAsync(MembersDeactivateArg membersDeactivateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersDeactivateArg, enc.Empty, MembersSuspendError>(membersDeactivateArg, "api", "/team/members/suspend", "team", global::Dropbox.Api.Team.MembersDeactivateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersSuspendError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersDeactivateArg, enc.Empty, MembersSuspendError>(membersDeactivateArg, "api", "/team/members/suspend", "team", global::Dropbox.Api.Team.MembersDeactivateArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersSuspendError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5354,17 +5514,19 @@ namespace Dropbox.Api.Team.Routes
         /// moved.</param>
         /// <param name="wipeData">If provided, controls if the user's data will be deleted on
         /// their linked devices.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersSuspendError"/>.</exception>
         public t.Task MembersSuspendAsync(UserSelectorArg user,
-                                          bool wipeData = true)
+                                          bool wipeData = true,
+                                          tr.CancellationToken cancellationToken = default)
         {
             var membersDeactivateArg = new MembersDeactivateArg(user,
                                                                 wipeData);
 
-            return this.MembersSuspendAsync(membersDeactivateArg);
+            return this.MembersSuspendAsync(membersDeactivateArg, cancellationToken);
         }
 
         /// <summary>
@@ -5415,13 +5577,14 @@ namespace Dropbox.Api.Team.Routes
         /// identify the user account.</para>
         /// </summary>
         /// <param name="membersUnsuspendArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersUnsuspendError"/>.</exception>
-        public t.Task MembersUnsuspendAsync(MembersUnsuspendArg membersUnsuspendArg)
+        public t.Task MembersUnsuspendAsync(MembersUnsuspendArg membersUnsuspendArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<MembersUnsuspendArg, enc.Empty, MembersUnsuspendError>(membersUnsuspendArg, "api", "/team/members/unsuspend", "team", global::Dropbox.Api.Team.MembersUnsuspendArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersUnsuspendError.Decoder);
+            return this.Transport.SendRpcRequestAsync<MembersUnsuspendArg, enc.Empty, MembersUnsuspendError>(membersUnsuspendArg, "api", "/team/members/unsuspend", "team", global::Dropbox.Api.Team.MembersUnsuspendArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.MembersUnsuspendError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5447,15 +5610,17 @@ namespace Dropbox.Api.Team.Routes
         /// identify the user account.</para>
         /// </summary>
         /// <param name="user">Identity of user to unsuspend.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="MembersUnsuspendError"/>.</exception>
-        public t.Task MembersUnsuspendAsync(UserSelectorArg user)
+        public t.Task MembersUnsuspendAsync(UserSelectorArg user,
+                                            tr.CancellationToken cancellationToken = default)
         {
             var membersUnsuspendArg = new MembersUnsuspendArg(user);
 
-            return this.MembersUnsuspendAsync(membersUnsuspendArg);
+            return this.MembersUnsuspendAsync(membersUnsuspendArg, cancellationToken);
         }
 
         /// <summary>
@@ -5502,14 +5667,15 @@ namespace Dropbox.Api.Team.Routes
         /// other teams. Duplicates may occur in the list.</para>
         /// </summary>
         /// <param name="teamNamespacesListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamNamespacesListError"/>.</exception>
-        public t.Task<TeamNamespacesListResult> NamespacesListAsync(TeamNamespacesListArg teamNamespacesListArg)
+        public t.Task<TeamNamespacesListResult> NamespacesListAsync(TeamNamespacesListArg teamNamespacesListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamNamespacesListArg, TeamNamespacesListResult, TeamNamespacesListError>(teamNamespacesListArg, "api", "/team/namespaces/list", "team", global::Dropbox.Api.Team.TeamNamespacesListArg.Encoder, global::Dropbox.Api.Team.TeamNamespacesListResult.Decoder, global::Dropbox.Api.Team.TeamNamespacesListError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamNamespacesListArg, TeamNamespacesListResult, TeamNamespacesListError>(teamNamespacesListArg, "api", "/team/namespaces/list", "team", global::Dropbox.Api.Team.TeamNamespacesListArg.Encoder, global::Dropbox.Api.Team.TeamNamespacesListResult.Decoder, global::Dropbox.Api.Team.TeamNamespacesListError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5536,16 +5702,18 @@ namespace Dropbox.Api.Team.Routes
         /// other teams. Duplicates may occur in the list.</para>
         /// </summary>
         /// <param name="limit">Specifying a value here has no effect.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamNamespacesListError"/>.</exception>
-        public t.Task<TeamNamespacesListResult> NamespacesListAsync(uint limit = 1000)
+        public t.Task<TeamNamespacesListResult> NamespacesListAsync(uint limit = 1000,
+                                                                    tr.CancellationToken cancellationToken = default)
         {
             var teamNamespacesListArg = new TeamNamespacesListArg(limit);
 
-            return this.NamespacesListAsync(teamNamespacesListArg);
+            return this.NamespacesListAsync(teamNamespacesListArg, cancellationToken);
         }
 
         /// <summary>
@@ -5594,14 +5762,15 @@ namespace Dropbox.Api.Team.Routes
         /// list.</para>
         /// </summary>
         /// <param name="teamNamespacesListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamNamespacesListContinueError"/>.</exception>
-        public t.Task<TeamNamespacesListResult> NamespacesListContinueAsync(TeamNamespacesListContinueArg teamNamespacesListContinueArg)
+        public t.Task<TeamNamespacesListResult> NamespacesListContinueAsync(TeamNamespacesListContinueArg teamNamespacesListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamNamespacesListContinueArg, TeamNamespacesListResult, TeamNamespacesListContinueError>(teamNamespacesListContinueArg, "api", "/team/namespaces/list/continue", "team", global::Dropbox.Api.Team.TeamNamespacesListContinueArg.Encoder, global::Dropbox.Api.Team.TeamNamespacesListResult.Decoder, global::Dropbox.Api.Team.TeamNamespacesListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamNamespacesListContinueArg, TeamNamespacesListResult, TeamNamespacesListContinueError>(teamNamespacesListContinueArg, "api", "/team/namespaces/list/continue", "team", global::Dropbox.Api.Team.TeamNamespacesListContinueArg.Encoder, global::Dropbox.Api.Team.TeamNamespacesListResult.Decoder, global::Dropbox.Api.Team.TeamNamespacesListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5628,16 +5797,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// team-accessible namespaces.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamNamespacesListContinueError"/>.</exception>
-        public t.Task<TeamNamespacesListResult> NamespacesListContinueAsync(string cursor)
+        public t.Task<TeamNamespacesListResult> NamespacesListContinueAsync(string cursor,
+                                                                            tr.CancellationToken cancellationToken = default)
         {
             var teamNamespacesListContinueArg = new TeamNamespacesListContinueArg(cursor);
 
-            return this.NamespacesListContinueAsync(teamNamespacesListContinueArg);
+            return this.NamespacesListContinueAsync(teamNamespacesListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -5684,15 +5855,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="addTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.ModifyTemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.AddTemplateResult> PropertiesTemplateAddAsync(global::Dropbox.Api.FileProperties.AddTemplateArg addTemplateArg)
+        public t.Task<global::Dropbox.Api.FileProperties.AddTemplateResult> PropertiesTemplateAddAsync(global::Dropbox.Api.FileProperties.AddTemplateArg addTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.AddTemplateArg, global::Dropbox.Api.FileProperties.AddTemplateResult, global::Dropbox.Api.FileProperties.ModifyTemplateError>(addTemplateArg, "api", "/team/properties/template/add", "team", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.AddTemplateArg, global::Dropbox.Api.FileProperties.AddTemplateResult, global::Dropbox.Api.FileProperties.ModifyTemplateError>(addTemplateArg, "api", "/team/properties/template/add", "team", global::Dropbox.Api.FileProperties.AddTemplateArg.Encoder, global::Dropbox.Api.FileProperties.AddTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5721,6 +5893,7 @@ namespace Dropbox.Api.Team.Routes
         /// be up to 1024 bytes.</param>
         /// <param name="fields">Definitions of the property fields associated with this
         /// template. There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -5729,13 +5902,14 @@ namespace Dropbox.Api.Team.Routes
         [sys.Obsolete("This function is deprecated")]
         public t.Task<global::Dropbox.Api.FileProperties.AddTemplateResult> PropertiesTemplateAddAsync(string name,
                                                                                                        string description,
-                                                                                                       col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyFieldTemplate> fields)
+                                                                                                       col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyFieldTemplate> fields,
+                                                                                                       tr.CancellationToken cancellationToken = default)
         {
             var addTemplateArg = new global::Dropbox.Api.FileProperties.AddTemplateArg(name,
                                                                                        description,
                                                                                        fields);
 
-            return this.PropertiesTemplateAddAsync(addTemplateArg);
+            return this.PropertiesTemplateAddAsync(addTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -5792,15 +5966,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="getTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(global::Dropbox.Api.FileProperties.GetTemplateArg getTemplateArg)
+        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(global::Dropbox.Api.FileProperties.GetTemplateArg getTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.GetTemplateArg, global::Dropbox.Api.FileProperties.GetTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(getTemplateArg, "api", "/team/properties/template/get", "team", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.GetTemplateArg, global::Dropbox.Api.FileProperties.GetTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(getTemplateArg, "api", "/team/properties/template/get", "team", global::Dropbox.Api.FileProperties.GetTemplateArg.Encoder, global::Dropbox.Api.FileProperties.GetTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5828,17 +6003,19 @@ namespace Dropbox.Api.Team.Routes
         /// /> or <see
         /// cref="Dropbox.Api.FileProperties.Routes.FilePropertiesTeamRoutes.TemplatesAddForTeamAsync"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(string templateId)
+        public t.Task<global::Dropbox.Api.FileProperties.GetTemplateResult> PropertiesTemplateGetAsync(string templateId,
+                                                                                                       tr.CancellationToken cancellationToken = default)
         {
             var getTemplateArg = new global::Dropbox.Api.FileProperties.GetTemplateArg(templateId);
 
-            return this.PropertiesTemplateGetAsync(getTemplateArg);
+            return this.PropertiesTemplateGetAsync(getTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -5889,15 +6066,16 @@ namespace Dropbox.Api.Team.Routes
         /// <summary>
         /// <para>Permission : Team member file access.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.TemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.ListTemplateResult> PropertiesTemplateListAsync()
+        public t.Task<global::Dropbox.Api.FileProperties.ListTemplateResult> PropertiesTemplateListAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, global::Dropbox.Api.FileProperties.ListTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(enc.Empty.Instance, "api", "/team/properties/template/list", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, global::Dropbox.Api.FileProperties.ListTemplateResult, global::Dropbox.Api.FileProperties.TemplateError>(enc.Empty.Instance, "api", "/team/properties/template/list", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.FileProperties.ListTemplateResult.Decoder, global::Dropbox.Api.FileProperties.TemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5942,15 +6120,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="updateTemplateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.FileProperties.ModifyTemplateError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<global::Dropbox.Api.FileProperties.UpdateTemplateResult> PropertiesTemplateUpdateAsync(global::Dropbox.Api.FileProperties.UpdateTemplateArg updateTemplateArg)
+        public t.Task<global::Dropbox.Api.FileProperties.UpdateTemplateResult> PropertiesTemplateUpdateAsync(global::Dropbox.Api.FileProperties.UpdateTemplateArg updateTemplateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.UpdateTemplateArg, global::Dropbox.Api.FileProperties.UpdateTemplateResult, global::Dropbox.Api.FileProperties.ModifyTemplateError>(updateTemplateArg, "api", "/team/properties/template/update", "team", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.FileProperties.UpdateTemplateArg, global::Dropbox.Api.FileProperties.UpdateTemplateResult, global::Dropbox.Api.FileProperties.ModifyTemplateError>(updateTemplateArg, "api", "/team/properties/template/update", "team", global::Dropbox.Api.FileProperties.UpdateTemplateArg.Encoder, global::Dropbox.Api.FileProperties.UpdateTemplateResult.Decoder, global::Dropbox.Api.FileProperties.ModifyTemplateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -5984,6 +6163,7 @@ namespace Dropbox.Api.Team.Routes
         /// can be up to 1024 bytes.</param>
         /// <param name="addFields">Property field templates to be added to the group template.
         /// There can be up to 32 properties in a single template.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -5993,14 +6173,15 @@ namespace Dropbox.Api.Team.Routes
         public t.Task<global::Dropbox.Api.FileProperties.UpdateTemplateResult> PropertiesTemplateUpdateAsync(string templateId,
                                                                                                              string name = null,
                                                                                                              string description = null,
-                                                                                                             col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyFieldTemplate> addFields = null)
+                                                                                                             col.IEnumerable<global::Dropbox.Api.FileProperties.PropertyFieldTemplate> addFields = null,
+                                                                                                             tr.CancellationToken cancellationToken = default)
         {
             var updateTemplateArg = new global::Dropbox.Api.FileProperties.UpdateTemplateArg(templateId,
                                                                                              name,
                                                                                              description,
                                                                                              addFields);
 
-            return this.PropertiesTemplateUpdateAsync(updateTemplateArg);
+            return this.PropertiesTemplateUpdateAsync(updateTemplateArg, cancellationToken);
         }
 
         /// <summary>
@@ -6064,15 +6245,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Retrieves reporting data about a team's user activity.</para>
         /// </summary>
         /// <param name="dateRange">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<GetActivityReport> ReportsGetActivityAsync(DateRange dateRange)
+        public t.Task<GetActivityReport> ReportsGetActivityAsync(DateRange dateRange, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DateRange, GetActivityReport, DateRangeError>(dateRange, "api", "/team/reports/get_activity", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetActivityReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DateRange, GetActivityReport, DateRangeError>(dateRange, "api", "/team/reports/get_activity", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetActivityReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6098,6 +6280,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="startDate">Optional starting date (inclusive). If start_date is None
         /// or too long ago, this field will  be set to 6 months ago.</param>
         /// <param name="endDate">Optional ending date (exclusive).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6105,12 +6288,13 @@ namespace Dropbox.Api.Team.Routes
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<GetActivityReport> ReportsGetActivityAsync(sys.DateTime? startDate = null,
-                                                                 sys.DateTime? endDate = null)
+                                                                 sys.DateTime? endDate = null,
+                                                                 tr.CancellationToken cancellationToken = default)
         {
             var dateRange = new DateRange(startDate,
                                           endDate);
 
-            return this.ReportsGetActivityAsync(dateRange);
+            return this.ReportsGetActivityAsync(dateRange, cancellationToken);
         }
 
         /// <summary>
@@ -6162,15 +6346,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Retrieves reporting data about a team's linked devices.</para>
         /// </summary>
         /// <param name="dateRange">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<GetDevicesReport> ReportsGetDevicesAsync(DateRange dateRange)
+        public t.Task<GetDevicesReport> ReportsGetDevicesAsync(DateRange dateRange, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DateRange, GetDevicesReport, DateRangeError>(dateRange, "api", "/team/reports/get_devices", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetDevicesReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DateRange, GetDevicesReport, DateRangeError>(dateRange, "api", "/team/reports/get_devices", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetDevicesReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6196,6 +6381,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="startDate">Optional starting date (inclusive). If start_date is None
         /// or too long ago, this field will  be set to 6 months ago.</param>
         /// <param name="endDate">Optional ending date (exclusive).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6203,12 +6389,13 @@ namespace Dropbox.Api.Team.Routes
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<GetDevicesReport> ReportsGetDevicesAsync(sys.DateTime? startDate = null,
-                                                               sys.DateTime? endDate = null)
+                                                               sys.DateTime? endDate = null,
+                                                               tr.CancellationToken cancellationToken = default)
         {
             var dateRange = new DateRange(startDate,
                                           endDate);
 
-            return this.ReportsGetDevicesAsync(dateRange);
+            return this.ReportsGetDevicesAsync(dateRange, cancellationToken);
         }
 
         /// <summary>
@@ -6260,15 +6447,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Retrieves reporting data about a team's membership.</para>
         /// </summary>
         /// <param name="dateRange">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<GetMembershipReport> ReportsGetMembershipAsync(DateRange dateRange)
+        public t.Task<GetMembershipReport> ReportsGetMembershipAsync(DateRange dateRange, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DateRange, GetMembershipReport, DateRangeError>(dateRange, "api", "/team/reports/get_membership", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetMembershipReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DateRange, GetMembershipReport, DateRangeError>(dateRange, "api", "/team/reports/get_membership", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetMembershipReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6294,6 +6482,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="startDate">Optional starting date (inclusive). If start_date is None
         /// or too long ago, this field will  be set to 6 months ago.</param>
         /// <param name="endDate">Optional ending date (exclusive).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6301,12 +6490,13 @@ namespace Dropbox.Api.Team.Routes
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<GetMembershipReport> ReportsGetMembershipAsync(sys.DateTime? startDate = null,
-                                                                     sys.DateTime? endDate = null)
+                                                                     sys.DateTime? endDate = null,
+                                                                     tr.CancellationToken cancellationToken = default)
         {
             var dateRange = new DateRange(startDate,
                                           endDate);
 
-            return this.ReportsGetMembershipAsync(dateRange);
+            return this.ReportsGetMembershipAsync(dateRange, cancellationToken);
         }
 
         /// <summary>
@@ -6358,15 +6548,16 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Retrieves reporting data about a team's storage usage.</para>
         /// </summary>
         /// <param name="dateRange">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
-        public t.Task<GetStorageReport> ReportsGetStorageAsync(DateRange dateRange)
+        public t.Task<GetStorageReport> ReportsGetStorageAsync(DateRange dateRange, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<DateRange, GetStorageReport, DateRangeError>(dateRange, "api", "/team/reports/get_storage", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetStorageReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder);
+            return this.Transport.SendRpcRequestAsync<DateRange, GetStorageReport, DateRangeError>(dateRange, "api", "/team/reports/get_storage", "team", global::Dropbox.Api.Team.DateRange.Encoder, global::Dropbox.Api.Team.GetStorageReport.Decoder, global::Dropbox.Api.Team.DateRangeError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6392,6 +6583,7 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="startDate">Optional starting date (inclusive). If start_date is None
         /// or too long ago, this field will  be set to 6 months ago.</param>
         /// <param name="endDate">Optional ending date (exclusive).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -6399,12 +6591,13 @@ namespace Dropbox.Api.Team.Routes
         /// cref="DateRangeError"/>.</exception>
         [sys.Obsolete("This function is deprecated")]
         public t.Task<GetStorageReport> ReportsGetStorageAsync(sys.DateTime? startDate = null,
-                                                               sys.DateTime? endDate = null)
+                                                               sys.DateTime? endDate = null,
+                                                               tr.CancellationToken cancellationToken = default)
         {
             var dateRange = new DateRange(startDate,
                                           endDate);
 
-            return this.ReportsGetStorageAsync(dateRange);
+            return this.ReportsGetStorageAsync(dateRange, cancellationToken);
         }
 
         /// <summary>
@@ -6457,14 +6650,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderIdArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderActivateError"/>.</exception>
-        public t.Task<TeamFolderMetadata> TeamFolderActivateAsync(TeamFolderIdArg teamFolderIdArg)
+        public t.Task<TeamFolderMetadata> TeamFolderActivateAsync(TeamFolderIdArg teamFolderIdArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderIdArg, TeamFolderMetadata, TeamFolderActivateError>(teamFolderIdArg, "api", "/team/team_folder/activate", "team", global::Dropbox.Api.Team.TeamFolderIdArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderActivateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderIdArg, TeamFolderMetadata, TeamFolderActivateError>(teamFolderIdArg, "api", "/team/team_folder/activate", "team", global::Dropbox.Api.Team.TeamFolderIdArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderActivateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6488,16 +6682,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderId">The ID of the team folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderActivateError"/>.</exception>
-        public t.Task<TeamFolderMetadata> TeamFolderActivateAsync(string teamFolderId)
+        public t.Task<TeamFolderMetadata> TeamFolderActivateAsync(string teamFolderId,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var teamFolderIdArg = new TeamFolderIdArg(teamFolderId);
 
-            return this.TeamFolderActivateAsync(teamFolderIdArg);
+            return this.TeamFolderActivateAsync(teamFolderIdArg, cancellationToken);
         }
 
         /// <summary>
@@ -6545,14 +6741,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderArchiveArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderArchiveError"/>.</exception>
-        public t.Task<TeamFolderArchiveLaunch> TeamFolderArchiveAsync(TeamFolderArchiveArg teamFolderArchiveArg)
+        public t.Task<TeamFolderArchiveLaunch> TeamFolderArchiveAsync(TeamFolderArchiveArg teamFolderArchiveArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderArchiveArg, TeamFolderArchiveLaunch, TeamFolderArchiveError>(teamFolderArchiveArg, "api", "/team/team_folder/archive", "team", global::Dropbox.Api.Team.TeamFolderArchiveArg.Encoder, global::Dropbox.Api.Team.TeamFolderArchiveLaunch.Decoder, global::Dropbox.Api.Team.TeamFolderArchiveError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderArchiveArg, TeamFolderArchiveLaunch, TeamFolderArchiveError>(teamFolderArchiveArg, "api", "/team/team_folder/archive", "team", global::Dropbox.Api.Team.TeamFolderArchiveArg.Encoder, global::Dropbox.Api.Team.TeamFolderArchiveLaunch.Decoder, global::Dropbox.Api.Team.TeamFolderArchiveError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6579,18 +6776,20 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="teamFolderId">The ID of the team folder.</param>
         /// <param name="forceAsyncOff">Whether to force the archive to happen
         /// synchronously.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderArchiveError"/>.</exception>
         public t.Task<TeamFolderArchiveLaunch> TeamFolderArchiveAsync(string teamFolderId,
-                                                                      bool forceAsyncOff = false)
+                                                                      bool forceAsyncOff = false,
+                                                                      tr.CancellationToken cancellationToken = default)
         {
             var teamFolderArchiveArg = new TeamFolderArchiveArg(teamFolderId,
                                                                 forceAsyncOff);
 
-            return this.TeamFolderArchiveAsync(teamFolderArchiveArg);
+            return this.TeamFolderArchiveAsync(teamFolderArchiveArg, cancellationToken);
         }
 
         /// <summary>
@@ -6641,14 +6840,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="pollArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<TeamFolderArchiveJobStatus> TeamFolderArchiveCheckAsync(global::Dropbox.Api.Async.PollArg pollArg)
+        public t.Task<TeamFolderArchiveJobStatus> TeamFolderArchiveCheckAsync(global::Dropbox.Api.Async.PollArg pollArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, TeamFolderArchiveJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/team_folder/archive/check", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Team.TeamFolderArchiveJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder);
+            return this.Transport.SendRpcRequestAsync<global::Dropbox.Api.Async.PollArg, TeamFolderArchiveJobStatus, global::Dropbox.Api.Async.PollError>(pollArg, "api", "/team/team_folder/archive/check", "team", global::Dropbox.Api.Async.PollArg.Encoder, global::Dropbox.Api.Team.TeamFolderArchiveJobStatus.Decoder, global::Dropbox.Api.Async.PollError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6673,16 +6873,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="asyncJobId">Id of the asynchronous job. This is the value of a
         /// response returned from the method that launched the job.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="global::Dropbox.Api.Async.PollError"/>.</exception>
-        public t.Task<TeamFolderArchiveJobStatus> TeamFolderArchiveCheckAsync(string asyncJobId)
+        public t.Task<TeamFolderArchiveJobStatus> TeamFolderArchiveCheckAsync(string asyncJobId,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var pollArg = new global::Dropbox.Api.Async.PollArg(asyncJobId);
 
-            return this.TeamFolderArchiveCheckAsync(pollArg);
+            return this.TeamFolderArchiveCheckAsync(pollArg, cancellationToken);
         }
 
         /// <summary>
@@ -6730,14 +6932,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderCreateArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderCreateError"/>.</exception>
-        public t.Task<TeamFolderMetadata> TeamFolderCreateAsync(TeamFolderCreateArg teamFolderCreateArg)
+        public t.Task<TeamFolderMetadata> TeamFolderCreateAsync(TeamFolderCreateArg teamFolderCreateArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderCreateArg, TeamFolderMetadata, TeamFolderCreateError>(teamFolderCreateArg, "api", "/team/team_folder/create", "team", global::Dropbox.Api.Team.TeamFolderCreateArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderCreateError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderCreateArg, TeamFolderMetadata, TeamFolderCreateError>(teamFolderCreateArg, "api", "/team/team_folder/create", "team", global::Dropbox.Api.Team.TeamFolderCreateArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderCreateError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6763,18 +6966,20 @@ namespace Dropbox.Api.Team.Routes
         /// <param name="name">Name for the new team folder.</param>
         /// <param name="syncSetting">The sync setting to apply to this team folder. Only
         /// permitted if the team has team selective sync enabled.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderCreateError"/>.</exception>
         public t.Task<TeamFolderMetadata> TeamFolderCreateAsync(string name,
-                                                                global::Dropbox.Api.Files.SyncSettingArg syncSetting = null)
+                                                                global::Dropbox.Api.Files.SyncSettingArg syncSetting = null,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var teamFolderCreateArg = new TeamFolderCreateArg(name,
                                                               syncSetting);
 
-            return this.TeamFolderCreateAsync(teamFolderCreateArg);
+            return this.TeamFolderCreateAsync(teamFolderCreateArg, cancellationToken);
         }
 
         /// <summary>
@@ -6825,11 +7030,12 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderIdListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<col.List<TeamFolderGetInfoItem>> TeamFolderGetInfoAsync(TeamFolderIdListArg teamFolderIdListArg)
+        public t.Task<col.List<TeamFolderGetInfoItem>> TeamFolderGetInfoAsync(TeamFolderIdListArg teamFolderIdListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderIdListArg, col.List<TeamFolderGetInfoItem>, enc.Empty>(teamFolderIdListArg, "api", "/team/team_folder/get_info", "team", global::Dropbox.Api.Team.TeamFolderIdListArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.TeamFolderGetInfoItem.Decoder), enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<TeamFolderIdListArg, col.List<TeamFolderGetInfoItem>, enc.Empty>(teamFolderIdListArg, "api", "/team/team_folder/get_info", "team", global::Dropbox.Api.Team.TeamFolderIdListArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Team.TeamFolderGetInfoItem.Decoder), enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -6853,13 +7059,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderIds">The list of team folder IDs.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<col.List<TeamFolderGetInfoItem>> TeamFolderGetInfoAsync(col.IEnumerable<string> teamFolderIds)
+        public t.Task<col.List<TeamFolderGetInfoItem>> TeamFolderGetInfoAsync(col.IEnumerable<string> teamFolderIds,
+                                                                              tr.CancellationToken cancellationToken = default)
         {
             var teamFolderIdListArg = new TeamFolderIdListArg(teamFolderIds);
 
-            return this.TeamFolderGetInfoAsync(teamFolderIdListArg);
+            return this.TeamFolderGetInfoAsync(teamFolderIdListArg, cancellationToken);
         }
 
         /// <summary>
@@ -6903,14 +7111,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderListArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderListError"/>.</exception>
-        public t.Task<TeamFolderListResult> TeamFolderListAsync(TeamFolderListArg teamFolderListArg)
+        public t.Task<TeamFolderListResult> TeamFolderListAsync(TeamFolderListArg teamFolderListArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderListArg, TeamFolderListResult, TeamFolderListError>(teamFolderListArg, "api", "/team/team_folder/list", "team", global::Dropbox.Api.Team.TeamFolderListArg.Encoder, global::Dropbox.Api.Team.TeamFolderListResult.Decoder, global::Dropbox.Api.Team.TeamFolderListError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderListArg, TeamFolderListResult, TeamFolderListError>(teamFolderListArg, "api", "/team/team_folder/list", "team", global::Dropbox.Api.Team.TeamFolderListArg.Encoder, global::Dropbox.Api.Team.TeamFolderListResult.Decoder, global::Dropbox.Api.Team.TeamFolderListError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -6934,16 +7143,18 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="limit">The maximum number of results to return per request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderListError"/>.</exception>
-        public t.Task<TeamFolderListResult> TeamFolderListAsync(uint limit = 1000)
+        public t.Task<TeamFolderListResult> TeamFolderListAsync(uint limit = 1000,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var teamFolderListArg = new TeamFolderListArg(limit);
 
-            return this.TeamFolderListAsync(teamFolderListArg);
+            return this.TeamFolderListAsync(teamFolderListArg, cancellationToken);
         }
 
         /// <summary>
@@ -6992,14 +7203,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderListContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderListContinueError"/>.</exception>
-        public t.Task<TeamFolderListResult> TeamFolderListContinueAsync(TeamFolderListContinueArg teamFolderListContinueArg)
+        public t.Task<TeamFolderListResult> TeamFolderListContinueAsync(TeamFolderListContinueArg teamFolderListContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderListContinueArg, TeamFolderListResult, TeamFolderListContinueError>(teamFolderListContinueArg, "api", "/team/team_folder/list/continue", "team", global::Dropbox.Api.Team.TeamFolderListContinueArg.Encoder, global::Dropbox.Api.Team.TeamFolderListResult.Decoder, global::Dropbox.Api.Team.TeamFolderListContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderListContinueArg, TeamFolderListResult, TeamFolderListContinueError>(teamFolderListContinueArg, "api", "/team/team_folder/list/continue", "team", global::Dropbox.Api.Team.TeamFolderListContinueArg.Encoder, global::Dropbox.Api.Team.TeamFolderListResult.Decoder, global::Dropbox.Api.Team.TeamFolderListContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -7026,16 +7238,18 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of team
         /// folders.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderListContinueError"/>.</exception>
-        public t.Task<TeamFolderListResult> TeamFolderListContinueAsync(string cursor)
+        public t.Task<TeamFolderListResult> TeamFolderListContinueAsync(string cursor,
+                                                                        tr.CancellationToken cancellationToken = default)
         {
             var teamFolderListContinueArg = new TeamFolderListContinueArg(cursor);
 
-            return this.TeamFolderListContinueAsync(teamFolderListContinueArg);
+            return this.TeamFolderListContinueAsync(teamFolderListContinueArg, cancellationToken);
         }
 
         /// <summary>
@@ -7083,13 +7297,14 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderIdArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderPermanentlyDeleteError"/>.</exception>
-        public t.Task TeamFolderPermanentlyDeleteAsync(TeamFolderIdArg teamFolderIdArg)
+        public t.Task TeamFolderPermanentlyDeleteAsync(TeamFolderIdArg teamFolderIdArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderIdArg, enc.Empty, TeamFolderPermanentlyDeleteError>(teamFolderIdArg, "api", "/team/team_folder/permanently_delete", "team", global::Dropbox.Api.Team.TeamFolderIdArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.TeamFolderPermanentlyDeleteError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderIdArg, enc.Empty, TeamFolderPermanentlyDeleteError>(teamFolderIdArg, "api", "/team/team_folder/permanently_delete", "team", global::Dropbox.Api.Team.TeamFolderIdArg.Encoder, enc.EmptyDecoder.Instance, global::Dropbox.Api.Team.TeamFolderPermanentlyDeleteError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -7114,15 +7329,17 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderId">The ID of the team folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderPermanentlyDeleteError"/>.</exception>
-        public t.Task TeamFolderPermanentlyDeleteAsync(string teamFolderId)
+        public t.Task TeamFolderPermanentlyDeleteAsync(string teamFolderId,
+                                                       tr.CancellationToken cancellationToken = default)
         {
             var teamFolderIdArg = new TeamFolderIdArg(teamFolderId);
 
-            return this.TeamFolderPermanentlyDeleteAsync(teamFolderIdArg);
+            return this.TeamFolderPermanentlyDeleteAsync(teamFolderIdArg, cancellationToken);
         }
 
         /// <summary>
@@ -7167,14 +7384,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Permission : Team member file access.</para>
         /// </summary>
         /// <param name="teamFolderRenameArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderRenameError"/>.</exception>
-        public t.Task<TeamFolderMetadata> TeamFolderRenameAsync(TeamFolderRenameArg teamFolderRenameArg)
+        public t.Task<TeamFolderMetadata> TeamFolderRenameAsync(TeamFolderRenameArg teamFolderRenameArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderRenameArg, TeamFolderMetadata, TeamFolderRenameError>(teamFolderRenameArg, "api", "/team/team_folder/rename", "team", global::Dropbox.Api.Team.TeamFolderRenameArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderRenameError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderRenameArg, TeamFolderMetadata, TeamFolderRenameError>(teamFolderRenameArg, "api", "/team/team_folder/rename", "team", global::Dropbox.Api.Team.TeamFolderRenameArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderRenameError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -7199,18 +7417,20 @@ namespace Dropbox.Api.Team.Routes
         /// </summary>
         /// <param name="teamFolderId">The ID of the team folder.</param>
         /// <param name="name">New team folder name.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderRenameError"/>.</exception>
         public t.Task<TeamFolderMetadata> TeamFolderRenameAsync(string teamFolderId,
-                                                                string name)
+                                                                string name,
+                                                                tr.CancellationToken cancellationToken = default)
         {
             var teamFolderRenameArg = new TeamFolderRenameArg(teamFolderId,
                                                               name);
 
-            return this.TeamFolderRenameAsync(teamFolderRenameArg);
+            return this.TeamFolderRenameAsync(teamFolderRenameArg, cancellationToken);
         }
 
         /// <summary>
@@ -7260,14 +7480,15 @@ namespace Dropbox.Api.Team.Routes
         /// endpoint requires that the team has team selective sync enabled.</para>
         /// </summary>
         /// <param name="teamFolderUpdateSyncSettingsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TeamFolderUpdateSyncSettingsError"/>.</exception>
-        public t.Task<TeamFolderMetadata> TeamFolderUpdateSyncSettingsAsync(TeamFolderUpdateSyncSettingsArg teamFolderUpdateSyncSettingsArg)
+        public t.Task<TeamFolderMetadata> TeamFolderUpdateSyncSettingsAsync(TeamFolderUpdateSyncSettingsArg teamFolderUpdateSyncSettingsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<TeamFolderUpdateSyncSettingsArg, TeamFolderMetadata, TeamFolderUpdateSyncSettingsError>(teamFolderUpdateSyncSettingsArg, "api", "/team/team_folder/update_sync_settings", "team", global::Dropbox.Api.Team.TeamFolderUpdateSyncSettingsArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderUpdateSyncSettingsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<TeamFolderUpdateSyncSettingsArg, TeamFolderMetadata, TeamFolderUpdateSyncSettingsError>(teamFolderUpdateSyncSettingsArg, "api", "/team/team_folder/update_sync_settings", "team", global::Dropbox.Api.Team.TeamFolderUpdateSyncSettingsArg.Encoder, global::Dropbox.Api.Team.TeamFolderMetadata.Decoder, global::Dropbox.Api.Team.TeamFolderUpdateSyncSettingsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -7296,6 +7517,7 @@ namespace Dropbox.Api.Team.Routes
         /// meaningful if the team folder is not a shared team root.</param>
         /// <param name="contentSyncSettings">Sync settings to apply to contents of this team
         /// folder.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -7303,13 +7525,14 @@ namespace Dropbox.Api.Team.Routes
         /// cref="TeamFolderUpdateSyncSettingsError"/>.</exception>
         public t.Task<TeamFolderMetadata> TeamFolderUpdateSyncSettingsAsync(string teamFolderId,
                                                                             global::Dropbox.Api.Files.SyncSettingArg syncSetting = null,
-                                                                            col.IEnumerable<global::Dropbox.Api.Files.ContentSyncSettingArg> contentSyncSettings = null)
+                                                                            col.IEnumerable<global::Dropbox.Api.Files.ContentSyncSettingArg> contentSyncSettings = null,
+                                                                            tr.CancellationToken cancellationToken = default)
         {
             var teamFolderUpdateSyncSettingsArg = new TeamFolderUpdateSyncSettingsArg(teamFolderId,
                                                                                       syncSetting,
                                                                                       contentSyncSettings);
 
-            return this.TeamFolderUpdateSyncSettingsAsync(teamFolderUpdateSyncSettingsArg);
+            return this.TeamFolderUpdateSyncSettingsAsync(teamFolderUpdateSyncSettingsArg, cancellationToken);
         }
 
         /// <summary>
@@ -7364,14 +7587,15 @@ namespace Dropbox.Api.Team.Routes
         /// <para>Returns the member profile of the admin who generated the team access token
         /// used to make the call.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="TokenGetAuthenticatedAdminError"/>.</exception>
-        public t.Task<TokenGetAuthenticatedAdminResult> TokenGetAuthenticatedAdminAsync()
+        public t.Task<TokenGetAuthenticatedAdminResult> TokenGetAuthenticatedAdminAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, TokenGetAuthenticatedAdminResult, TokenGetAuthenticatedAdminError>(enc.Empty.Instance, "api", "/team/token/get_authenticated_admin", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.Team.TokenGetAuthenticatedAdminResult.Decoder, global::Dropbox.Api.Team.TokenGetAuthenticatedAdminError.Decoder);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, TokenGetAuthenticatedAdminResult, TokenGetAuthenticatedAdminError>(enc.Empty.Instance, "api", "/team/token/get_authenticated_admin", "team", enc.EmptyEncoder.Instance, global::Dropbox.Api.Team.TokenGetAuthenticatedAdminResult.Decoder, global::Dropbox.Api.Team.TokenGetAuthenticatedAdminError.Decoder, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/TeamLog/TeamLogTeamRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/TeamLog/TeamLogTeamRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.TeamLog.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -48,14 +49,15 @@ namespace Dropbox.Api.TeamLog.Routes
         /// <para>Permission : Team Auditing.</para>
         /// </summary>
         /// <param name="getTeamEventsArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetTeamEventsError"/>.</exception>
-        public t.Task<GetTeamEventsResult> GetEventsAsync(GetTeamEventsArg getTeamEventsArg)
+        public t.Task<GetTeamEventsResult> GetEventsAsync(GetTeamEventsArg getTeamEventsArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTeamEventsArg, GetTeamEventsResult, GetTeamEventsError>(getTeamEventsArg, "api", "/team_log/get_events", "team", global::Dropbox.Api.TeamLog.GetTeamEventsArg.Encoder, global::Dropbox.Api.TeamLog.GetTeamEventsResult.Decoder, global::Dropbox.Api.TeamLog.GetTeamEventsError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetTeamEventsArg, GetTeamEventsResult, GetTeamEventsError>(getTeamEventsArg, "api", "/team_log/get_events", "team", global::Dropbox.Api.TeamLog.GetTeamEventsArg.Encoder, global::Dropbox.Api.TeamLog.GetTeamEventsResult.Decoder, global::Dropbox.Api.TeamLog.GetTeamEventsError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -104,6 +106,7 @@ namespace Dropbox.Api.TeamLog.Routes
         /// category shouldn't be provided together with event_type.</param>
         /// <param name="eventType">Filter the returned events to a single event type. Note
         /// that event_type shouldn't be provided together with category.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
@@ -113,7 +116,8 @@ namespace Dropbox.Api.TeamLog.Routes
                                                           string accountId = null,
                                                           global::Dropbox.Api.TeamCommon.TimeRange time = null,
                                                           EventCategory category = null,
-                                                          EventTypeArg eventType = null)
+                                                          EventTypeArg eventType = null,
+                                                          tr.CancellationToken cancellationToken = default)
         {
             var getTeamEventsArg = new GetTeamEventsArg(limit,
                                                         accountId,
@@ -121,7 +125,7 @@ namespace Dropbox.Api.TeamLog.Routes
                                                         category,
                                                         eventType);
 
-            return this.GetEventsAsync(getTeamEventsArg);
+            return this.GetEventsAsync(getTeamEventsArg, cancellationToken);
         }
 
         /// <summary>
@@ -190,14 +194,15 @@ namespace Dropbox.Api.TeamLog.Routes
         /// <para>Permission : Team Auditing.</para>
         /// </summary>
         /// <param name="getTeamEventsContinueArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetTeamEventsContinueError"/>.</exception>
-        public t.Task<GetTeamEventsResult> GetEventsContinueAsync(GetTeamEventsContinueArg getTeamEventsContinueArg)
+        public t.Task<GetTeamEventsResult> GetEventsContinueAsync(GetTeamEventsContinueArg getTeamEventsContinueArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetTeamEventsContinueArg, GetTeamEventsResult, GetTeamEventsContinueError>(getTeamEventsContinueArg, "api", "/team_log/get_events/continue", "team", global::Dropbox.Api.TeamLog.GetTeamEventsContinueArg.Encoder, global::Dropbox.Api.TeamLog.GetTeamEventsResult.Decoder, global::Dropbox.Api.TeamLog.GetTeamEventsContinueError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetTeamEventsContinueArg, GetTeamEventsResult, GetTeamEventsContinueError>(getTeamEventsContinueArg, "api", "/team_log/get_events/continue", "team", global::Dropbox.Api.TeamLog.GetTeamEventsContinueArg.Encoder, global::Dropbox.Api.TeamLog.GetTeamEventsResult.Decoder, global::Dropbox.Api.TeamLog.GetTeamEventsContinueError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -224,16 +229,18 @@ namespace Dropbox.Api.TeamLog.Routes
         /// </summary>
         /// <param name="cursor">Indicates from what point to get the next set of
         /// events.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetTeamEventsContinueError"/>.</exception>
-        public t.Task<GetTeamEventsResult> GetEventsContinueAsync(string cursor)
+        public t.Task<GetTeamEventsResult> GetEventsContinueAsync(string cursor,
+                                                                  tr.CancellationToken cancellationToken = default)
         {
             var getTeamEventsContinueArg = new GetTeamEventsContinueArg(cursor);
 
-            return this.GetEventsContinueAsync(getTeamEventsContinueArg);
+            return this.GetEventsContinueAsync(getTeamEventsContinueArg, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Generated/Users/UsersUserRoutes.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Generated/Users/UsersUserRoutes.cs
@@ -8,6 +8,7 @@ namespace Dropbox.Api.Users.Routes
     using io = System.IO;
     using col = System.Collections.Generic;
     using t = System.Threading.Tasks;
+    using tr = System.Threading;
     using enc = Dropbox.Api.Stone;
 
     /// <summary>
@@ -35,14 +36,15 @@ namespace Dropbox.Api.Users.Routes
         /// account.</para>
         /// </summary>
         /// <param name="userFeaturesGetValuesBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UserFeaturesGetValuesBatchError"/>.</exception>
-        public t.Task<UserFeaturesGetValuesBatchResult> FeaturesGetValuesAsync(UserFeaturesGetValuesBatchArg userFeaturesGetValuesBatchArg)
+        public t.Task<UserFeaturesGetValuesBatchResult> FeaturesGetValuesAsync(UserFeaturesGetValuesBatchArg userFeaturesGetValuesBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<UserFeaturesGetValuesBatchArg, UserFeaturesGetValuesBatchResult, UserFeaturesGetValuesBatchError>(userFeaturesGetValuesBatchArg, "api", "/users/features/get_values", "user", global::Dropbox.Api.Users.UserFeaturesGetValuesBatchArg.Encoder, global::Dropbox.Api.Users.UserFeaturesGetValuesBatchResult.Decoder, global::Dropbox.Api.Users.UserFeaturesGetValuesBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<UserFeaturesGetValuesBatchArg, UserFeaturesGetValuesBatchResult, UserFeaturesGetValuesBatchError>(userFeaturesGetValuesBatchArg, "api", "/users/features/get_values", "user", global::Dropbox.Api.Users.UserFeaturesGetValuesBatchArg.Encoder, global::Dropbox.Api.Users.UserFeaturesGetValuesBatchResult.Decoder, global::Dropbox.Api.Users.UserFeaturesGetValuesBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -68,16 +70,18 @@ namespace Dropbox.Api.Users.Routes
         /// <param name="features">A list of features in <see cref="UserFeature" />. If the
         /// list is empty, this route will return <see cref="UserFeaturesGetValuesBatchError"
         /// />.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="UserFeaturesGetValuesBatchError"/>.</exception>
-        public t.Task<UserFeaturesGetValuesBatchResult> FeaturesGetValuesAsync(col.IEnumerable<UserFeature> features)
+        public t.Task<UserFeaturesGetValuesBatchResult> FeaturesGetValuesAsync(col.IEnumerable<UserFeature> features,
+                                                                               tr.CancellationToken cancellationToken = default)
         {
             var userFeaturesGetValuesBatchArg = new UserFeaturesGetValuesBatchArg(features);
 
-            return this.FeaturesGetValuesAsync(userFeaturesGetValuesBatchArg);
+            return this.FeaturesGetValuesAsync(userFeaturesGetValuesBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -125,14 +129,15 @@ namespace Dropbox.Api.Users.Routes
         /// <para>Get information about a user's account.</para>
         /// </summary>
         /// <param name="getAccountArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetAccountError"/>.</exception>
-        public t.Task<BasicAccount> GetAccountAsync(GetAccountArg getAccountArg)
+        public t.Task<BasicAccount> GetAccountAsync(GetAccountArg getAccountArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetAccountArg, BasicAccount, GetAccountError>(getAccountArg, "api", "/users/get_account", "user", global::Dropbox.Api.Users.GetAccountArg.Encoder, global::Dropbox.Api.Users.BasicAccount.Decoder, global::Dropbox.Api.Users.GetAccountError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetAccountArg, BasicAccount, GetAccountError>(getAccountArg, "api", "/users/get_account", "user", global::Dropbox.Api.Users.GetAccountArg.Encoder, global::Dropbox.Api.Users.BasicAccount.Decoder, global::Dropbox.Api.Users.GetAccountError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -155,16 +160,18 @@ namespace Dropbox.Api.Users.Routes
         /// <para>Get information about a user's account.</para>
         /// </summary>
         /// <param name="accountId">A user's account identifier.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetAccountError"/>.</exception>
-        public t.Task<BasicAccount> GetAccountAsync(string accountId)
+        public t.Task<BasicAccount> GetAccountAsync(string accountId,
+                                                    tr.CancellationToken cancellationToken = default)
         {
             var getAccountArg = new GetAccountArg(accountId);
 
-            return this.GetAccountAsync(getAccountArg);
+            return this.GetAccountAsync(getAccountArg, cancellationToken);
         }
 
         /// <summary>
@@ -211,14 +218,15 @@ namespace Dropbox.Api.Users.Routes
         /// queried per request.</para>
         /// </summary>
         /// <param name="getAccountBatchArg">The request parameters</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetAccountBatchError"/>.</exception>
-        public t.Task<col.List<BasicAccount>> GetAccountBatchAsync(GetAccountBatchArg getAccountBatchArg)
+        public t.Task<col.List<BasicAccount>> GetAccountBatchAsync(GetAccountBatchArg getAccountBatchArg, tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<GetAccountBatchArg, col.List<BasicAccount>, GetAccountBatchError>(getAccountBatchArg, "api", "/users/get_account_batch", "user", global::Dropbox.Api.Users.GetAccountBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Users.BasicAccount.Decoder), global::Dropbox.Api.Users.GetAccountBatchError.Decoder);
+            return this.Transport.SendRpcRequestAsync<GetAccountBatchArg, col.List<BasicAccount>, GetAccountBatchError>(getAccountBatchArg, "api", "/users/get_account_batch", "user", global::Dropbox.Api.Users.GetAccountBatchArg.Encoder, enc.Decoder.CreateListDecoder(global::Dropbox.Api.Users.BasicAccount.Decoder), global::Dropbox.Api.Users.GetAccountBatchError.Decoder, cancellationToken);
         }
 
         /// <summary>
@@ -243,16 +251,18 @@ namespace Dropbox.Api.Users.Routes
         /// </summary>
         /// <param name="accountIds">List of user account identifiers.  Should not contain any
         /// duplicate account IDs.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
         /// <exception cref="Dropbox.Api.ApiException{TError}">Thrown if there is an error
         /// processing the request; This will contain a <see
         /// cref="GetAccountBatchError"/>.</exception>
-        public t.Task<col.List<BasicAccount>> GetAccountBatchAsync(col.IEnumerable<string> accountIds)
+        public t.Task<col.List<BasicAccount>> GetAccountBatchAsync(col.IEnumerable<string> accountIds,
+                                                                   tr.CancellationToken cancellationToken = default)
         {
             var getAccountBatchArg = new GetAccountBatchArg(accountIds);
 
-            return this.GetAccountBatchAsync(getAccountBatchArg);
+            return this.GetAccountBatchAsync(getAccountBatchArg, cancellationToken);
         }
 
         /// <summary>
@@ -298,11 +308,12 @@ namespace Dropbox.Api.Users.Routes
         /// <summary>
         /// <para>Get information about the current user's account.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<FullAccount> GetCurrentAccountAsync()
+        public t.Task<FullAccount> GetCurrentAccountAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, FullAccount, enc.Empty>(enc.Empty.Instance, "api", "/users/get_current_account", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.Users.FullAccount.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, FullAccount, enc.Empty>(enc.Empty.Instance, "api", "/users/get_current_account", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.Users.FullAccount.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>
@@ -341,11 +352,12 @@ namespace Dropbox.Api.Users.Routes
         /// <summary>
         /// <para>Get the space usage information for the current user's account.</para>
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task that represents the asynchronous send operation. The TResult
         /// parameter contains the response from the server.</returns>
-        public t.Task<SpaceUsage> GetSpaceUsageAsync()
+        public t.Task<SpaceUsage> GetSpaceUsageAsync(tr.CancellationToken cancellationToken = default)
         {
-            return this.Transport.SendRpcRequestAsync<enc.Empty, SpaceUsage, enc.Empty>(enc.Empty.Instance, "api", "/users/get_space_usage", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.Users.SpaceUsage.Decoder, enc.EmptyDecoder.Instance);
+            return this.Transport.SendRpcRequestAsync<enc.Empty, SpaceUsage, enc.Empty>(enc.Empty.Instance, "api", "/users/get_space_usage", "user", enc.EmptyEncoder.Instance, global::Dropbox.Api.Users.SpaceUsage.Decoder, enc.EmptyDecoder.Instance, cancellationToken);
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/Stone/Encoder.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Stone/Encoder.cs
@@ -8,6 +8,8 @@ namespace Dropbox.Api.Stone
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The factory class for encoders.
@@ -52,15 +54,17 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(T? value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(T? value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
             if (value == null)
             {
-                writer.WriteNull();
+                await writer.WriteNull(cancellationToken);
                 return;
             }
 
-            this.encoder.Encode(value.Value, writer);
+            await this.encoder.Encode(value.Value, writer, cancellationToken);
         }
     }
 
@@ -84,9 +88,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(int value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(int value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteInt32(value);
+            await writer.WriteInt32(value, cancellationToken);
         }
     }
 
@@ -110,9 +116,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(long value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(long value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteInt64(value);
+            await writer.WriteInt64(value, cancellationToken);
         }
     }
 
@@ -136,9 +144,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(uint value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(uint value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteUInt32(value);
+            await writer.WriteUInt32(value, cancellationToken);
         }
     }
 
@@ -162,9 +172,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(ulong value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(ulong value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteUInt64(value);
+            await writer.WriteUInt64(value, cancellationToken);
         }
     }
 
@@ -183,9 +195,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(float value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(float value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteSingle(value);
+            await writer.WriteSingle(value, cancellationToken);
         }
     }
 
@@ -209,9 +223,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(double value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(double value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteDouble(value);
+            await writer.WriteDouble(value, cancellationToken);
         }
     }
 
@@ -235,9 +251,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(bool value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(bool value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteBoolean(value);
+            await writer.WriteBoolean(value, cancellationToken);
         }
     }
 
@@ -261,9 +279,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(DateTime value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(DateTime value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteDateTime(value);
+            await writer.WriteDateTime(value, cancellationToken);
         }
     }
 
@@ -282,9 +302,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(byte[] value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(byte[] value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteBytes(value);
+            await writer.WriteBytes(value, cancellationToken);
         }
     }
 
@@ -303,9 +325,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(string value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(string value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            writer.WriteString(value);
+            await writer.WriteString(value, cancellationToken);
         }
     }
 
@@ -324,8 +348,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(Empty value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public Task Encode(Empty value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
+            return Task.CompletedTask;
         }
     }
 
@@ -341,17 +368,19 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(T value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(T value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
             if (value == null)
             {
-                writer.WriteNull();
+                await writer.WriteNull(cancellationToken);
                 return;
             }
 
-            writer.WriteStartObject();
+            await writer.WriteStartObject(cancellationToken);
             this.EncodeFields(value, writer);
-            writer.WriteEndObject();
+            await writer.WriteEndObject(cancellationToken);
         }
 
         /// <summary>
@@ -369,10 +398,12 @@ namespace Dropbox.Api.Stone
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
         /// <param name="encoder">The encoder.</param>
-        protected static void WriteProperty<TProperty>(string propertyName, TProperty value, IJsonWriter writer, IEncoder<TProperty> encoder)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected static async Task WriteProperty<TProperty>(string propertyName, TProperty value, IJsonWriter writer, IEncoder<TProperty> encoder, CancellationToken cancellationToken = default)
         {
-            writer.WritePropertyName(propertyName);
-            encoder.Encode(value, writer);
+            await writer.WritePropertyName(propertyName, cancellationToken);
+            await encoder.Encode(value, writer, cancellationToken);
         }
 
         /// <summary>
@@ -383,10 +414,12 @@ namespace Dropbox.Api.Stone
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
         /// <param name="encoder">The encoder.</param>
-        protected static void WriteListProperty<TProperty>(string propertyName, IList<TProperty> value, IJsonWriter writer, IEncoder<TProperty> encoder)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected static async Task WriteListProperty<TProperty>(string propertyName, IList<TProperty> value, IJsonWriter writer, IEncoder<TProperty> encoder, CancellationToken cancellationToken = default)
         {
-            writer.WritePropertyName(propertyName);
-            ListEncoder<TProperty>.Encode(value, writer, encoder);
+            await writer.WritePropertyName(propertyName, cancellationToken);
+            await ListEncoder<TProperty>.Encode(value, writer, encoder, cancellationToken);
         }
     }
 
@@ -416,16 +449,18 @@ namespace Dropbox.Api.Stone
         /// <param name="value">The list.</param>
         /// <param name="writer">The writer.</param>
         /// <param name="itemEncoder">The item encoder.</param>
-        public static void Encode(IList<T> value, IJsonWriter writer, IEncoder<T> itemEncoder)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public static async Task Encode(IList<T> value, IJsonWriter writer, IEncoder<T> itemEncoder, CancellationToken cancellationToken = default)
         {
-            writer.WriteStartArray();
+            await writer.WriteStartArray(cancellationToken);
 
             foreach (var item in value)
             {
-                itemEncoder.Encode(item, writer);
+                await itemEncoder.Encode(item, writer, cancellationToken);
             }
 
-            writer.WriteEndArray();
+            await writer.WriteEndArray(cancellationToken);
         }
 
         /// <summary>
@@ -433,9 +468,11 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        public void Encode(IList<T> value, IJsonWriter writer)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task Encode(IList<T> value, IJsonWriter writer, CancellationToken cancellationToken = default)
         {
-            Encode(value, writer, this.itemEncoder);
+            await Encode(value, writer, this.itemEncoder, cancellationToken);
         }
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/Stone/IEncoder.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Stone/IEncoder.cs
@@ -6,8 +6,8 @@
 
 namespace Dropbox.Api.Stone
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The encoder interface.
@@ -20,6 +20,8 @@ namespace Dropbox.Api.Stone
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="writer">The writer.</param>
-        void Encode(T value, IJsonWriter writer);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task Encode(T value, IJsonWriter writer, CancellationToken cancellationToken = default);
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/Stone/IJsonWriter.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Stone/IJsonWriter.cs
@@ -7,6 +7,8 @@
 namespace Dropbox.Api.Stone
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The json writer interface.
@@ -17,91 +19,123 @@ namespace Dropbox.Api.Stone
         /// Write a Int32 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteInt32(int value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteInt32(int value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a Int64 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteInt64(long value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteInt64(long value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a UInt32 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteUInt32(uint value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteUInt32(uint value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a UInt64 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteUInt64(ulong value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteUInt64(ulong value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a double value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteDouble(double value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteDouble(double value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a single value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteSingle(float value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteSingle(float value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a DateTime value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteDateTime(DateTime value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteDateTime(DateTime value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a boolean value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteBoolean(bool value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteBoolean(bool value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a byte[] value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteBytes(byte[] value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteBytes(byte[] value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a string value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void WriteString(string value);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteString(string value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a null value.
         /// </summary>
-        void WriteNull();
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteNull(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write start object.
         /// </summary>
-        void WriteStartObject();
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteStartObject(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write end object.
         /// </summary>
-        void WriteEndObject();
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteEndObject(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write start array.
         /// </summary>
-        void WriteStartArray();
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteStartArray(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write end array.
         /// </summary>
-        void WriteEndArray();
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WriteEndArray(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write property name.
         /// </summary>
         /// <param name="name">The property name.</param>
-        void WritePropertyName(string name);
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task WritePropertyName(string name, CancellationToken cancellationToken = default);
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/Stone/ITransport.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Stone/ITransport.cs
@@ -7,8 +7,8 @@
 namespace Dropbox.Api.Stone
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -71,7 +71,8 @@ namespace Dropbox.Api.Stone
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder);
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sends the upload request asynchronously.
@@ -96,7 +97,8 @@ namespace Dropbox.Api.Stone
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder);
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sends the download request asynchronously.
@@ -119,6 +121,7 @@ namespace Dropbox.Api.Stone
             string auth,
             IEncoder<TRequest> requestEncoder,
             IDecoder<TResponse> responseDecoder,
-            IDecoder<TError> errorDecoder);
+            IDecoder<TError> errorDecoder,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/Stone/JsonWriter.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Stone/JsonWriter.cs
@@ -10,7 +10,8 @@ namespace Dropbox.Api.Stone
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
-
+    using System.Threading;
+    using System.Threading.Tasks;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -39,8 +40,9 @@ namespace Dropbox.Api.Stone
         /// <param name="encodable">The object to write.</param>
         /// <param name="encoder">The encoder.</param>
         /// <param name="escapeNonAscii">If escape non-ascii characters.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The encoded object as a JSON string.</returns>
-        public static string Write<T>(T encodable, IEncoder<T> encoder, bool escapeNonAscii = false)
+        public static async Task<string> WriteAsync<T>(T encodable, IEncoder<T> encoder, bool escapeNonAscii = false, CancellationToken cancellationToken = default)
         {
             var builder = new StringBuilder();
             var textWriter = new JsonTextWriter(new StringWriter(builder)) { DateFormatString = "yyyy-MM-ddTHH:mm:ssZ" };
@@ -51,7 +53,7 @@ namespace Dropbox.Api.Stone
             }
 
             var writer = new JsonWriter(textWriter);
-            encoder.Encode(encodable, writer);
+            await encoder.Encode(encodable, writer, cancellationToken);
 
             var json = builder.ToString();
 
@@ -62,139 +64,171 @@ namespace Dropbox.Api.Stone
         /// Write a Int32 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteInt32(int value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteInt32(int value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a Int64 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteInt64(long value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteInt64(long value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a UInt32 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteUInt32(uint value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteUInt32(uint value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a UInt64 value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteUInt64(ulong value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteUInt64(ulong value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a double value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteDouble(double value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteDouble(double value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a single value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteSingle(float value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteSingle(float value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a DateTime value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteDateTime(DateTime value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteDateTime(DateTime value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value.ToUniversalTime());
+            await this.writer.WriteValueAsync(value.ToUniversalTime(), cancellationToken);
         }
 
         /// <summary>
         /// Write a boolean value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteBoolean(bool value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteBoolean(bool value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a byte[] value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteBytes(byte[] value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteBytes(byte[] value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a string value.
         /// </summary>
         /// <param name="value">The value.</param>
-        void IJsonWriter.WriteString(string value)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteString(string value, CancellationToken cancellationToken)
         {
-            this.writer.WriteValue(value);
+            await this.writer.WriteValueAsync(value, cancellationToken);
         }
 
         /// <summary>
         /// Write a null value.
         /// </summary>
-        void IJsonWriter.WriteNull()
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteNull(CancellationToken cancellationToken)
         {
-            this.writer.WriteNull();
+            await this.writer.WriteNullAsync(cancellationToken);
         }
 
         /// <summary>
         /// Write start object.
         /// </summary>
-        void IJsonWriter.WriteStartObject()
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteStartObject(CancellationToken cancellationToken)
         {
-            this.writer.WriteStartObject();
+            await this.writer.WriteStartObjectAsync(cancellationToken);
         }
 
         /// <summary>
         /// Write end object.
         /// </summary>
-        void IJsonWriter.WriteEndObject()
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteEndObject(CancellationToken cancellationToken)
         {
-            this.writer.WriteEndObject();
+            await this.writer.WriteEndObjectAsync(cancellationToken);
         }
 
         /// <summary>
         /// Write start array.
         /// </summary>
-        void IJsonWriter.WriteStartArray()
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteStartArray(CancellationToken cancellationToken)
         {
-            this.writer.WriteStartArray();
+            await this.writer.WriteStartArrayAsync(cancellationToken);
         }
 
         /// <summary>
         /// Write end array.
         /// </summary>
-        void IJsonWriter.WriteEndArray()
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WriteEndArray(CancellationToken cancellationToken)
         {
-            this.writer.WriteEndArray();
+            await this.writer.WriteEndArrayAsync(cancellationToken);
         }
 
         /// <summary>
         /// Write property name.
         /// </summary>
         /// <param name="name">The property name.</param>
-        void IJsonWriter.WritePropertyName(string name)
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        async Task IJsonWriter.WritePropertyName(string name, CancellationToken cancellationToken)
         {
-            this.writer.WritePropertyName(name);
+            await this.writer.WritePropertyNameAsync(name, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This is an attempt to add cancellation capability to async methods by adding the CancellationToken optional argument as follows:
1. Changed csharp.py code generator to add the CancellationToken to Async methods.
2. Changed DropboxRequestHandler to support cancellation while calling HttpClient methods and while performing the retry.
3. Changed DropboxClient to support cancellation for RefreshAccessToken.
4. Adding cancellation support to JsonWriter by using the async overloads of Newtonsoft.
5. I didn't implement the cancellation for JsonReader since it's called after the request is completed.
<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does this code build successfully?
- [ ] Do all tests pass?
- [x] Does Stylecop pass?

